### PR TITLE
[christmas] remove unnecessary comment in Cargo.toml

### DIFF
--- a/christmas/Cargo.toml
+++ b/christmas/Cargo.toml
@@ -9,8 +9,6 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true, optional = true }


### PR DESCRIPTION
Removed unnecessary comment about keys and their definitions in christmas/Cargo.toml