### PR TITLE
[tracingx] add comprehensive tracing utilities and configuration options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,6 +6728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9948,7 +9957,9 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -10398,6 +10409,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/lib/tracingx/Cargo.toml
+++ b/lib/tracingx/Cargo.toml
@@ -12,4 +12,30 @@ license.workspace = true
 
 [dependencies]
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "json", "registry"] }
+
+[features]
+default = ["fmt", "env-filter"]
+# Format features
+fmt = ["tracing-subscriber/fmt"]
+json = ["tracing-subscriber/json"]
+# Filter features
+env-filter = ["tracing-subscriber/env-filter"]
+# Registry features
+registry = ["tracing-subscriber/registry"]
+# Additional features you might want to expose
+ansi = ["tracing-subscriber/ansi"]
+time = ["tracing-subscriber/time"]
+local-time = ["tracing-subscriber/local-time"]
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"
+
+[[example]]
+name = "advanced"
+path = "examples/advanced.rs"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/lib/tracingx/README.md
+++ b/lib/tracingx/README.md
@@ -1,0 +1,259 @@
+### Disclaimer
+
+Claude Opus 4.1 wrote all this. Hopefully most of it is correct.
+
+# tracingx
+
+A convenience wrapper around the `tracing` and `tracing-subscriber` crates that provides:
+
+- Re-exported tracing macros for simpler dependency management
+- Multiple pre-configured initialization patterns
+- Platform-aware logging (different behavior for WASM vs native)
+- Flexible configuration API for custom setups
+
+## Why tracingx?
+
+### Single Dependency Point
+
+Instead of adding both `tracing` and `tracing-subscriber` to your `Cargo.toml`, you only need `tracingx`:
+
+```toml
+[dependencies]
+tracingx = { path = "../../lib/tracingx" }
+# No need for direct tracing dependency!
+```
+
+### Consistent Versions
+
+All your projects use the same version of tracing that tracingx uses, avoiding version conflicts.
+
+### Re-exported Macros
+
+All tracing macros are re-exported, so you can import everything from one place:
+
+```rust
+use tracingx::{info, debug, warn, error, trace, instrument};
+// Or use the prelude:
+use tracingx::prelude::*;
+```
+
+## Quick Start
+
+### Basic Usage
+
+```rust
+use tracingx::{info, debug, warn, error};
+
+fn main() {
+    // Initialize with default settings (JSON format, info level)
+    tracingx::init_logging();
+
+    info!("Application started");
+    debug!("Debug information");
+    warn!("Warning message");
+    error!("Error occurred");
+}
+```
+
+### Development Mode
+
+```rust
+fn main() {
+    // Pretty printing with debug level - great for development
+    tracingx::init_dev();
+
+    info!("This will be beautifully formatted");
+}
+```
+
+### Production Mode
+
+```rust
+fn main() {
+    // JSON format with info level - perfect for production logs
+    tracingx::init_prod();
+
+    info!("Structured JSON logs for your log aggregation system");
+}
+```
+
+## Initialization Options
+
+### Pre-configured Functions
+
+```rust
+// JSON format (default)
+tracingx::init_logging();
+
+// Pretty format for human reading
+tracingx::init_pretty();
+
+// Compact single-line format
+tracingx::init_compact();
+
+// Development preset (pretty + debug level)
+tracingx::init_dev();
+
+// Production preset (JSON + info level)
+tracingx::init_prod();
+
+// With custom filter
+tracingx::init_with_env_filter(Some("debug,hyper=warn"));
+
+// Initialize only if not already initialized
+tracingx::init_once();
+```
+
+### Custom Configuration
+
+```rust
+use tracingx::{LoggingConfig, LogFormat};
+
+fn main() {
+    LoggingConfig::new()
+        .with_filter("debug")
+        .with_format(LogFormat::Pretty)
+        .show_file(true)
+        .show_line_number(true)
+        .show_thread_names(true)
+        .ansi_colors(true)
+        .init();
+}
+```
+
+## Structured Logging
+
+```rust
+use tracingx::{info, debug};
+
+#[derive(Debug)]
+struct User {
+    id: u64,
+    name: String,
+}
+
+fn process_user(user: &User) {
+    // Log with structured fields
+    info!(
+        user.id = user.id,
+        user.name = %user.name,
+        "Processing user"
+    );
+
+    // Use debug formatting
+    debug!(?user, "User details");
+}
+```
+
+## Spans and Context
+
+```rust
+use tracingx::{info_span, debug_span, instrument};
+
+fn main() {
+    tracingx::init_pretty();
+
+    let span = info_span!("main_operation", request_id = 123);
+    let _enter = span.enter();
+
+    info!("This log includes the span context");
+    nested_operation();
+}
+
+#[instrument]
+fn nested_operation() {
+    debug!("This function is automatically instrumented");
+}
+```
+
+## Platform Support
+
+### Native (Non-WASM)
+
+- Full featured logging with timestamps
+- JSON, Pretty, Compact, and Full formats
+- Thread names, file locations, line numbers
+- ANSI color support
+
+### WebAssembly
+
+- Simplified format without timestamps
+- Automatic ANSI color disabling
+- Optimized for browser console output
+
+## Environment Variables
+
+Control log levels using the `RUST_LOG` environment variable:
+
+```bash
+# Set global level
+RUST_LOG=debug cargo run
+
+# Set per-module levels
+RUST_LOG=debug,hyper=warn,tower=error cargo run
+
+# Filter by target
+RUST_LOG=my_app=debug cargo run
+```
+
+## Testing
+
+```rust
+#[cfg(test)]
+mod tests {
+    use tracingx::{info, debug};
+
+    #[test]
+    fn test_with_logging() {
+        // Initialize test logging (captured unless test fails)
+        tracingx::init_test();
+
+        info!("Test started");
+        debug!("Debug info in test");
+
+        // Your test logic here
+        assert_eq!(2 + 2, 4);
+    }
+}
+```
+
+## Examples
+
+Run the examples to see different configurations:
+
+```bash
+# Basic example with re-exported macros
+cargo run --example basic
+
+# Advanced configurations
+cargo run --example advanced -- json
+cargo run --example advanced -- pretty
+cargo run --example advanced -- dev
+cargo run --example advanced -- prod
+```
+
+## Features
+
+Default features: `["fmt", "env-filter"]`
+
+Available features:
+
+- `fmt` - Formatting layer support
+- `json` - JSON formatting
+- `env-filter` - Environment variable filtering
+- `registry` - Registry layer support
+- `ansi` - ANSI color support
+- `time` - Timestamp support
+- `local-time` - Local timestamp support
+
+## Best Practices
+
+1. **Initialize once at program start** - Call initialization in `main()` before any logging
+2. **Use structured logging** - Add context with fields rather than formatting in strings
+3. **Use spans for context** - Wrap operations in spans to maintain context
+4. **Configure per environment** - Use `init_dev()` for development, `init_prod()` for production
+5. **Use the prelude** - Import `tracingx::prelude::*` for convenient access to common items
+
+## License
+
+Same as parent workspace

--- a/lib/tracingx/examples/advanced.rs
+++ b/lib/tracingx/examples/advanced.rs
@@ -1,0 +1,257 @@
+//! Advanced example demonstrating different initialization options in tracingx
+//!
+//! Run different examples:
+//! ```
+//! cargo run --example advanced -- json
+//! cargo run --example advanced -- pretty
+//! cargo run --example advanced -- compact
+//! cargo run --example advanced -- custom
+//! cargo run --example advanced -- dev
+//! cargo run --example advanced -- prod
+//! ```
+
+use std::{env, error::Error};
+
+use tracingx::{LogFormat, LoggingConfig, debug, error, info, trace, warn};
+
+#[derive(Debug)]
+struct Order {
+    id: u64,
+    customer_id: u64,
+    total: f64,
+    items: Vec<String>,
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mode = args.get(1).map(|s| s.as_str()).unwrap_or("json");
+
+    match mode {
+        "json" => {
+            // Default JSON logging
+            tracingx::init_logging();
+            info!("Initialized with JSON format");
+        }
+        "pretty" => {
+            // Pretty printing for development
+            tracingx::init_pretty();
+            info!("Initialized with pretty format");
+        }
+        "compact" => {
+            // Compact single-line format
+            tracingx::init_compact();
+            info!("Initialized with compact format");
+        }
+        "custom" => {
+            // Custom configuration
+            LoggingConfig::new()
+                .with_filter("trace")
+                .with_format(LogFormat::Pretty)
+                .show_target(true)
+                .show_level(true)
+                .show_file(true)
+                .show_line_number(true)
+                .show_thread_names(true)
+                .ansi_colors(true)
+                .init();
+            info!("Initialized with custom configuration");
+        }
+        "dev" => {
+            // Development preset
+            tracingx::init_dev();
+            info!("Initialized with dev preset");
+        }
+        "prod" => {
+            // Production preset
+            tracingx::init_prod();
+            info!("Initialized with production preset");
+        }
+        _ => {
+            // With custom filter
+            tracingx::init_with_env_filter(Some("debug"));
+            info!("Initialized with custom filter");
+        }
+    }
+
+    demonstrate_logging();
+    demonstrate_structured_logging();
+    demonstrate_error_handling();
+    demonstrate_async_context().unwrap();
+}
+
+fn demonstrate_logging() {
+    let span = tracingx::info_span!("demonstrate_logging");
+    let _enter = span.enter();
+
+    trace!("Trace level - most verbose");
+    debug!("Debug level - debugging info");
+    info!("Info level - general information");
+    warn!("Warn level - warning messages");
+    error!("Error level - error messages");
+}
+
+fn demonstrate_structured_logging() {
+    let order = Order {
+        id: 12345,
+        customer_id: 67890,
+        total: 299.99,
+        items: vec!["Widget A".to_string(), "Widget B".to_string(), "Widget C".to_string()],
+    };
+
+    // Structured logging with multiple fields
+    info!(
+        order.id = order.id,
+        order.customer_id = order.customer_id,
+        order.total = order.total,
+        order.item_count = order.items.len(),
+        "Order received"
+    );
+
+    // Using debug representation
+    debug!(?order, "Order details");
+
+    // Nested span with inherited context
+    let order_span = tracingx::info_span!(
+        "process_order",
+        order.id = order.id,
+        order.customer_id = order.customer_id
+    );
+    let _order_guard = order_span.enter();
+
+    info!("Validating order");
+    validate_order(&order);
+    info!("Processing payment");
+    process_payment(&order);
+    info!("Order completed");
+}
+
+fn validate_order(order: &Order) {
+    debug!(items = ?order.items, "Checking inventory");
+
+    for (i, item) in order.items.iter().enumerate() {
+        trace!(item_index = i, item_name = %item, "Checking item availability");
+    }
+}
+
+fn process_payment(order: &Order) {
+    let payment_span = tracingx::debug_span!("payment", amount = order.total);
+    let _payment_guard = payment_span.enter();
+
+    debug!("Initiating payment");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    info!("Payment processed successfully");
+}
+
+fn demonstrate_error_handling() {
+    let result = risky_operation();
+
+    match result {
+        Ok(value) => {
+            info!(value, "Operation succeeded");
+        }
+        Err(err) => {
+            error!(%err, "Operation failed");
+
+            // Log with error chain if available
+            let mut source = err.source();
+            let mut level = 0;
+            while let Some(err) = source {
+                error!(cause_level = level, cause = %err, "Error cause");
+                source = err.source();
+                level += 1;
+            }
+        }
+    }
+}
+
+fn risky_operation() -> Result<i32, RiskyError> {
+    Err(RiskyError::new("Something went wrong"))
+}
+
+#[derive(Debug)]
+struct RiskyError {
+    message: String,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl RiskyError {
+    fn new(msg: &str) -> Self {
+        Self {
+            message: msg.to_string(),
+            source: Some(Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Underlying IO error",
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for RiskyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Risky operation error: {}", self.message)
+    }
+}
+
+impl std::error::Error for RiskyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| &**e as &(dyn std::error::Error + 'static))
+    }
+}
+
+fn demonstrate_async_context() -> Result<(), Box<dyn std::error::Error>> {
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    // Simulate async context with manual future
+    struct AsyncOperation {
+        completed: bool,
+    }
+
+    impl Future for AsyncOperation {
+        type Output = String;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if !self.completed {
+                debug!("Async operation in progress");
+                self.completed = true;
+                Poll::Pending
+            } else {
+                info!("Async operation completed");
+                Poll::Ready("Success".to_string())
+            }
+        }
+    }
+
+    let operation = AsyncOperation { completed: false };
+
+    // Use Instrument to attach span to async operation
+    let _instrumented =
+        tracingx::Instrument::instrument(operation, tracingx::info_span!("async_operation", task_id = 42));
+
+    info!("Async context demonstrated (without actual async runtime)");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_logging_initialization() {
+        // Use init_once to avoid double initialization in tests
+        let initialized = tracingx::init_once();
+
+        if initialized {
+            info!("Test logging initialized");
+        } else {
+            info!("Test logging was already initialized");
+        }
+
+        debug!("Running test");
+        assert!(tracingx::is_initialized());
+    }
+}

--- a/lib/tracingx/examples/basic.rs
+++ b/lib/tracingx/examples/basic.rs
@@ -1,0 +1,91 @@
+//! Example demonstrating how to use tracingx with re-exported macros
+//!
+//! Run with:
+//! ```
+//! cargo run --example basic
+//! ```
+//!
+//! Try different log levels:
+//! ```
+//! RUST_LOG=debug cargo run --example basic
+//! RUST_LOG=trace cargo run --example basic
+//! ```
+
+// Import everything from tracingx instead of tracing directly
+use tracingx::{debug, error, info, prelude::*, trace, warn};
+
+#[derive(Debug)]
+struct User {
+    id: u64,
+    name: String,
+    email: String,
+}
+
+fn main() {
+    // Initialize logging using tracingx's convenience function
+    tracingx::init_logging();
+
+    // Basic logging at different levels
+    trace!("This is a trace message - most verbose");
+    debug!("This is a debug message");
+    info!("Application starting");
+    warn!("This is a warning");
+    error!("This is an error (but not a panic!)");
+
+    // Structured logging with fields
+    let user = User {
+        id: 42,
+        name: "Alice".to_string(),
+        email: "alice@example.com".to_string(),
+    };
+
+    info!(
+        user.id = user.id,
+        user.name = %user.name,
+        user.email = %user.email,
+        "User logged in"
+    );
+
+    // Using spans for context
+    let span = info_span!("process_request", request_id = 123);
+    let _enter = span.enter();
+
+    info!("Processing request");
+    do_some_work();
+    info!("Request completed");
+
+    // Using the instrument attribute (if you have a function)
+    instrumented_function();
+
+    // Demonstrate nested spans
+    demonstrate_nested_spans();
+}
+
+fn do_some_work() {
+    debug!("Doing some work...");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    debug!("Work completed");
+}
+
+#[instrument]
+fn instrumented_function() {
+    info!("This function is automatically instrumented");
+    debug!("Any logs in here will be associated with this function's span");
+}
+
+fn demonstrate_nested_spans() {
+    let outer_span = info_span!("outer_operation", id = 1);
+    let _outer = outer_span.enter();
+
+    info!("Starting outer operation");
+
+    {
+        let inner_span = debug_span!("inner_operation", id = 2);
+        let _inner = inner_span.enter();
+
+        debug!("Performing inner operation");
+        trace!("Very detailed trace information");
+    }
+
+    info!("Outer operation complete");
+}

--- a/lib/tracingx/src/lib.rs
+++ b/lib/tracingx/src/lib.rs
@@ -1,3 +1,32 @@
 mod tracingx;
 
-pub use tracingx::init_logging;
+// Re-export all convenience functions from tracingx module
+// Re-export common tracing types
+pub use tracing::{
+    Dispatch, Event, Instrument, Level, Metadata, Span, Subscriber, dispatcher, enabled, field, level_filters,
+    subscriber,
+};
+// Re-export tracing macros
+pub use tracing::{
+    debug, debug_span, error, error_span, event, info, info_span, instrument, span, trace, trace_span, warn, warn_span,
+};
+// Re-export tracing_subscriber utilities that users might need
+pub use tracing_subscriber::{
+    EnvFilter, Registry, fmt,
+    layer::{Layer, SubscriberExt},
+    util::SubscriberInitExt,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use tracingx::init_test;
+pub use tracingx::{
+    LogFormat, LoggingConfig, init_compact, init_compact_with_filter, init_dev, init_logging, init_once,
+    init_once_with, init_pretty, init_pretty_with_filter, init_prod, init_with_env_filter, is_initialized,
+};
+
+// Prelude module for convenient imports
+pub mod prelude {
+    pub use super::{
+        Event, Instrument, Level, Span, debug, debug_span, error, error_span, info, info_span, init_logging,
+        instrument, span, trace, trace_span, warn, warn_span,
+    };
+}

--- a/lib/tracingx/src/tracingx.rs
+++ b/lib/tracingx/src/tracingx.rs
@@ -1,25 +1,33 @@
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
-/// Initialize structured JSON logging for the Dioxus server
+/// Initialize structured JSON logging with default settings
 pub fn init_logging() {
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    init_with_env_filter(None);
+}
+
+/// Initialize logging with a custom environment filter string
+pub fn init_with_env_filter(filter: Option<&str>) {
+    let env_filter = match filter {
+        Some(f) => EnvFilter::new(f),
+        None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+    };
 
     #[cfg(target_arch = "wasm32")]
     {
         // For WebAssembly, use a simpler format without timestamps
-        let fmt_layer = tracing_subscriber::fmt::layer()
+        let fmt_layer = fmt::layer()
             .with_ansi(false)
             .without_time() // Disable timestamps in WebAssembly
             .with_target(true)
             .with_level(true);
 
-        tracing_subscriber::registry().with(env_filter).with(fmt_layer).init();
+        Registry::default().with(env_filter).with(fmt_layer).init();
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     {
         // For non-WebAssembly platforms, use full JSON logging with timestamps
-        let json_layer = tracing_subscriber::fmt::layer()
+        let json_layer = fmt::layer()
             .json()
             .with_current_span(false)
             .with_span_list(true)
@@ -29,6 +37,241 @@ pub fn init_logging() {
             .with_file(true)
             .with_line_number(true);
 
-        tracing_subscriber::registry().with(env_filter).with(json_layer).init();
+        Registry::default().with(env_filter).with(json_layer).init();
+    }
+}
+
+/// Initialize human-readable logging (pretty format)
+pub fn init_pretty() {
+    init_pretty_with_filter(None);
+}
+
+/// Initialize human-readable logging with custom filter
+pub fn init_pretty_with_filter(filter: Option<&str>) {
+    let env_filter = match filter {
+        Some(f) => EnvFilter::new(f),
+        None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+    };
+
+    let fmt_layer = fmt::layer()
+        .pretty()
+        .with_target(true)
+        .with_level(true)
+        .with_thread_names(false)
+        .with_file(true)
+        .with_line_number(true);
+
+    Registry::default().with(env_filter).with(fmt_layer).init();
+}
+
+/// Initialize compact logging (single line per log)
+pub fn init_compact() {
+    init_compact_with_filter(None);
+}
+
+/// Initialize compact logging with custom filter
+pub fn init_compact_with_filter(filter: Option<&str>) {
+    let env_filter = match filter {
+        Some(f) => EnvFilter::new(f),
+        None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+    };
+
+    let fmt_layer = fmt::layer()
+        .compact()
+        .with_target(true)
+        .with_level(true)
+        .with_thread_names(false)
+        .with_file(false)
+        .with_line_number(false);
+
+    Registry::default().with(env_filter).with(fmt_layer).init();
+}
+
+/// Initialize test logging (useful for tests)
+/// This captures logs but doesn't print them unless the test fails
+#[cfg(not(target_arch = "wasm32"))]
+pub fn init_test() {
+    let _ = Registry::default()
+        .with(fmt::layer().with_test_writer().with_target(true).with_level(true))
+        .try_init();
+}
+
+/// Configuration builder for more complex setups
+pub struct LoggingConfig {
+    filter: Option<String>,
+    format: LogFormat,
+    show_target: bool,
+    show_level: bool,
+    show_file: bool,
+    show_line_number: bool,
+    show_thread_names: bool,
+    ansi_colors: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LogFormat {
+    Json,
+    Pretty,
+    Compact,
+    Full,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            filter: None,
+            format: LogFormat::Json,
+            show_target: true,
+            show_level: true,
+            show_file: true,
+            show_line_number: true,
+            show_thread_names: false,
+            ansi_colors: true,
+        }
+    }
+}
+
+impl LoggingConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_filter<S: Into<String>>(mut self, filter: S) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    pub fn with_format(mut self, format: LogFormat) -> Self {
+        self.format = format;
+        self
+    }
+
+    pub fn show_target(mut self, show: bool) -> Self {
+        self.show_target = show;
+        self
+    }
+
+    pub fn show_level(mut self, show: bool) -> Self {
+        self.show_level = show;
+        self
+    }
+
+    pub fn show_file(mut self, show: bool) -> Self {
+        self.show_file = show;
+        self
+    }
+
+    pub fn show_line_number(mut self, show: bool) -> Self {
+        self.show_line_number = show;
+        self
+    }
+
+    pub fn show_thread_names(mut self, show: bool) -> Self {
+        self.show_thread_names = show;
+        self
+    }
+
+    pub fn ansi_colors(mut self, enabled: bool) -> Self {
+        self.ansi_colors = enabled;
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn init(self) {
+        let env_filter = match self.filter {
+            Some(f) => EnvFilter::new(f),
+            None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        };
+
+        let base_fmt = fmt::layer()
+            .with_target(self.show_target)
+            .with_level(self.show_level)
+            .with_file(self.show_file)
+            .with_line_number(self.show_line_number)
+            .with_thread_names(self.show_thread_names)
+            .with_ansi(self.ansi_colors);
+
+        match self.format {
+            LogFormat::Json => {
+                Registry::default()
+                    .with(env_filter)
+                    .with(base_fmt.json().with_current_span(false).with_span_list(true))
+                    .init();
+            }
+            LogFormat::Pretty => {
+                Registry::default().with(env_filter).with(base_fmt.pretty()).init();
+            }
+            LogFormat::Compact => {
+                Registry::default().with(env_filter).with(base_fmt.compact()).init();
+            }
+            LogFormat::Full => {
+                Registry::default().with(env_filter).with(base_fmt).init();
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn init(self) {
+        let env_filter = match self.filter {
+            Some(f) => EnvFilter::new(f),
+            None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        };
+
+        // For WebAssembly, always use a simpler format
+        let fmt_layer = fmt::layer()
+            .with_ansi(false)
+            .without_time()
+            .with_target(self.show_target)
+            .with_level(self.show_level);
+
+        Registry::default().with(env_filter).with(fmt_layer).init();
+    }
+}
+
+/// Initialize logging for development with pretty printing and debug level
+pub fn init_dev() {
+    LoggingConfig::new()
+        .with_filter("debug")
+        .with_format(LogFormat::Pretty)
+        .show_file(true)
+        .show_line_number(true)
+        .init();
+}
+
+/// Initialize logging for production with JSON format and info level
+pub fn init_prod() {
+    LoggingConfig::new()
+        .with_filter("info")
+        .with_format(LogFormat::Json)
+        .show_file(false)
+        .show_line_number(false)
+        .show_thread_names(true)
+        .init();
+}
+
+/// Check if a tracing subscriber has already been set
+/// Useful to avoid double-initialization in tests
+pub fn is_initialized() -> bool {
+    tracing::dispatcher::has_been_set()
+}
+
+/// Initialize logging only if not already initialized
+/// Returns true if initialization was performed, false if already initialized
+pub fn init_once() -> bool {
+    if !is_initialized() {
+        init_logging();
+        true
+    } else {
+        false
+    }
+}
+
+/// Initialize logging with custom configuration only if not already initialized
+pub fn init_once_with(config: LoggingConfig) -> bool {
+    if !is_initialized() {
+        config.init();
+        true
+    } else {
+        false
     }
 }


### PR DESCRIPTION
# Add tracingx convenience wrapper for tracing and tracing-subscriber

This PR adds a comprehensive wrapper around the `tracing` and `tracing-subscriber` crates to simplify logging setup and usage. The key improvements include:

- Re-exports all common tracing macros (`info`, `debug`, `warn`, etc.) and types
- Provides multiple pre-configured initialization patterns:
  - `init_logging()` - JSON format (default)
  - `init_pretty()` - Human-readable format
  - `init_compact()` - Single-line compact format
  - `init_dev()` - Development preset with pretty format and debug level
  - `init_prod()` - Production preset with JSON format and info level

- Adds a flexible `LoggingConfig` builder API for custom logging setups
- Includes platform-aware behavior (different settings for WASM vs native)
- Provides utilities like `init_once()` to prevent double initialization
- Adds a prelude module for convenient imports

The PR also includes comprehensive examples and documentation:
- `basic.rs` example showing simple usage with re-exported macros
- `advanced.rs` example demonstrating different initialization options
- Detailed README with usage examples and best practices

This simplifies dependency management by providing a single entry point for tracing functionality while maintaining all the power of the underlying libraries.