### PR TITLE
[christmas] replace tracing with tracingx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,6 @@ dependencies = [
  "start",
  "thiserror 2.0.16",
  "tokio",
- "tracing",
  "tracingx",
 ]
 

--- a/christmas/Cargo.toml
+++ b/christmas/Cargo.toml
@@ -22,7 +22,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 start = { path = "../lib/start" }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 tracingx = { path = "../lib/tracingx" }
 tokio = { workspace = true, features = ["full"], optional = true }
 sqlx = { workspace = true, optional = true, features = ["chrono"]}

--- a/christmas/src/database/postgres.rs
+++ b/christmas/src/database/postgres.rs
@@ -7,7 +7,7 @@ use crate::{
 const PARTICIPANTS: &str = include_str!("../../assets/participants.yaml");
 
 pub async fn initialize(conn: &PgPool) -> Result<()> {
-    tracing::info!("running migrations...");
+    tracingx::info!("running migrations...");
 
     let migrations_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
     sqlx::migrate::Migrator::new(migrations_path).await?.run(conn).await?;

--- a/christmas/src/server/launch.rs
+++ b/christmas/src/server/launch.rs
@@ -13,7 +13,7 @@ use crate::database;
 pub async fn launch(app: fn() -> Element, use_embedded: bool) {
     tracingx::init_logging();
     let app_meta = AppMeta::from_env();
-    let root_span = tracing::info_span!("app", app = %app_meta.app, region = %app_meta.region, host = %app_meta.host);
+    let root_span = tracingx::info_span!("app", app = %app_meta.app, region = %app_meta.region, host = %app_meta.host);
     let _span = root_span.enter();
 
     let mut db = None::<PostgreSQL>;
@@ -35,7 +35,7 @@ pub async fn launch(app: fn() -> Element, use_embedded: bool) {
         db = Some(embedded_db);
     }
 
-    tracing::info!("using database: {url}");
+    tracingx::info!("using database: {url}");
     let db_conn = sqlx::PgPool::connect(&url).await.expect("db connection failed");
 
     database::initialize(&db_conn).await.expect("db initialize failed");
@@ -49,7 +49,7 @@ pub async fn launch(app: fn() -> Element, use_embedded: bool) {
         .serve_dioxus_application(ServeConfigBuilder::default().context(db_conn).build().unwrap(), app)
         .into_make_service();
 
-    tracing::info!(port = port, address = ip.to_string(), "Server started successfully");
+    tracingx::info!(port = port, address = ip.to_string(), "Server started successfully");
     axum::serve(listener, router).await.unwrap();
 
     if let Some(db) = db {


### PR DESCRIPTION
Replace `tracing` with `tracingx` in the Christmas crate

This PR removes the direct dependency on `tracing` from the Christmas crate and replaces all `tracing::` calls with `tracingx::` equivalents. The change affects logging statements in the database initialization and server launch code.