### PR TITLE
[arenabuddy] use desktop platform only. Fix workspace dioxus settings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tracingx",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,7 @@ console-subscriber = "0.4.1"
 csv = { version = "1.3.1" }
 ctrlc = "3.4.7"
 derive_builder = "0.20.2"
-dioxus = { version = "0.7.0-rc.0", features = [
-    "router",
-    "fullstack",
-] }
+dioxus = { version = "0.7.0-rc.0"}
 fastrand = "2.3.0"
 indoc = "2.0.6"
 itertools = "0.14.0"

--- a/arenabuddy/arenabuddy/Cargo.toml
+++ b/arenabuddy/arenabuddy/Cargo.toml
@@ -16,7 +16,7 @@ arenabuddy_data = { path = "../arenabuddy_data" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
-dioxus = { workspace = true, features = ["desktop"] }
+dioxus = { workspace = true, features = ["desktop", "router"] }
 itertools = { workspace = true }
 notify = { workspace = true }
 open = { workspace = true }

--- a/arenabuddy/arenabuddy_core/Cargo.toml
+++ b/arenabuddy/arenabuddy_core/Cargo.toml
@@ -21,6 +21,7 @@ ctrlc = { workspace = true }
 derive_builder = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }
+notify = { workspace = true}
 prost = { workspace = true }
 prost-types = { workspace = true }
 regex = { workspace = true }
@@ -29,7 +30,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracingx = { path = "../../lib/tracingx"}
-notify = { workspace = true}
+uuid = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
### TL;DR

Updated Dioxus feature flags and added UUID dependency to arenabuddy_core.

### What changed?

- Removed `router` and `fullstack` features from the root Dioxus dependency
- Added the `router` feature to the Dioxus dependency in arenabuddy/arenabuddy
- Reorganized dependencies in arenabuddy_core/Cargo.toml for better readability
- Added UUID dependency to arenabuddy_core

### Why make this change?

This change optimizes the Dioxus feature flags by only enabling them where needed rather than at the workspace level. The UUID dependency was added to arenabuddy_core to support unique identifier generation, will be used later.