### PR TITLE
[arenabuddy] initial draft parsing. logging only for now

### DIFF
--- a/.sqlx/query-d94dd3d5f8a9d50bb0c06412f85d322bb4ee1372299962fc11978b9f5aef4473.json
+++ b/.sqlx/query-d94dd3d5f8a9d50bb0c06412f85d322bb4ee1372299962fc11978b9f5aef4473.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT id, set_code, draft_format, status, created_at\n                FROM draft\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "draft",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "set_code",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "draft",
+            "name": "set_code"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "draft_format",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "draft",
+            "name": "draft_format"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "status",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "draft",
+            "name": "status"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamp",
+        "origin": {
+          "Table": {
+            "table": "draft",
+            "name": "created_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "d94dd3d5f8a9d50bb0c06412f85d322bb4ee1372299962fc11978b9f5aef4473"
+}

--- a/arenabuddy/arenabuddy_core/src/draft.rs
+++ b/arenabuddy/arenabuddy_core/src/draft.rs
@@ -1,0 +1,78 @@
+#![expect(dead_code)]
+#![expect(clippy::similar_names)]
+use derive_builder::Builder;
+
+use crate::{
+    models::Draft,
+    mtga_events::{
+        business::{BusinessEvent, DraftPackInfoEvent},
+        draft::RequestTypeDraftNotify,
+        primitives::ArenaId,
+    },
+};
+
+#[derive(Debug, Builder)]
+pub struct MTGADraft {
+    draft: Draft,
+    packs: Vec<(RawPack, RawPick)>,
+}
+
+#[derive(Debug, Clone)]
+struct RawPack {
+    pack_number: u8,
+    pick_number: u8,
+    cards: Vec<ArenaId>,
+}
+
+#[derive(Debug, Clone)]
+struct RawPick {
+    card_id: ArenaId,
+    pick_time_seconds: f64,
+}
+
+pub struct DraftBuilder {
+    builder: MTGADraftBuilder,
+}
+
+impl Default for DraftBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DraftBuilder {
+    pub fn new() -> Self {
+        Self {
+            builder: MTGADraftBuilder::default(),
+        }
+    }
+
+    // not sure if this is needed yet
+    pub fn process_notify_event(&mut self, _event: &RequestTypeDraftNotify) {}
+
+    pub fn process_business_event(&mut self, event: &BusinessEvent) {
+        if let BusinessEvent::Draft(e) = event {
+            self.process_pack_event(e);
+        }
+    }
+
+    fn process_pack_event(&mut self, draft_pack_info_event: &DraftPackInfoEvent) {
+        let pick = RawPick {
+            card_id: draft_pack_info_event.pick_grp_id,
+            pick_time_seconds: draft_pack_info_event.time_remaining_on_pick,
+        };
+
+        let pack = RawPack {
+            cards: draft_pack_info_event.cards_in_pack.clone(),
+            pack_number: draft_pack_info_event.pack_number,
+            pick_number: draft_pack_info_event.pick_number,
+        };
+
+        tracingx::info!("Pack #{}, Pick #{}", pack.pack_number, pack.pick_number);
+        if let Some(packs) = self.builder.packs.as_mut() {
+            packs.push((pack, pick));
+        } else {
+            self.builder.packs = Some(vec![(pack, pick)]);
+        }
+    }
+}

--- a/arenabuddy/arenabuddy_core/src/lib.rs
+++ b/arenabuddy/arenabuddy_core/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod cards;
 pub mod display;
+pub mod draft;
 pub mod errors;
 pub mod events;
 pub mod ingest;

--- a/arenabuddy/arenabuddy_core/src/models/draft.rs
+++ b/arenabuddy/arenabuddy_core/src/models/draft.rs
@@ -1,0 +1,84 @@
+#![expect(dead_code)]
+#![expect(clippy::similar_names)]
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::mtga_events::primitives::ArenaId;
+
+#[derive(Debug, Clone)]
+pub struct Draft {
+    id: Uuid,
+    set_code: String,
+    format: String,
+    status: String,
+    created_at: DateTime<Utc>,
+}
+
+impl Draft {
+    pub fn new(id: Uuid, set_code: String, format: String, status: String, created_at: DateTime<Utc>) -> Self {
+        Self {
+            id,
+            set_code,
+            format,
+            status,
+            created_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DraftPack {
+    id: u64,
+    draft_id: Uuid,
+    pack_number: u8,
+    pick_number: u8,
+    cards: Vec<ArenaId>,
+    created_at: DateTime<Utc>,
+}
+
+impl DraftPack {
+    pub fn new(
+        id: u64,
+        draft_id: Uuid,
+        pack_number: u8,
+        pick_number: u8,
+        cards: Vec<ArenaId>,
+        created_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id,
+            draft_id,
+            pack_number,
+            pick_number,
+            cards,
+            created_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DraftPick {
+    id: u64,
+    draft_pack_id: u64,
+    card_id: ArenaId,
+    pick_time_seconds: f64,
+    created_at: DateTime<Utc>,
+}
+
+impl DraftPick {
+    pub fn new(
+        id: u64,
+        draft_pack_id: u64,
+        card_id: ArenaId,
+        pick_time_seconds: f64,
+        created_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id,
+            draft_pack_id,
+            card_id,
+            pick_time_seconds,
+            created_at,
+        }
+    }
+}

--- a/arenabuddy/arenabuddy_core/src/models/mod.rs
+++ b/arenabuddy/arenabuddy_core/src/models/mod.rs
@@ -1,5 +1,6 @@
 mod card;
 mod deck;
+mod draft;
 mod mana;
 mod match_result;
 mod mtga_match;
@@ -7,6 +8,7 @@ mod mulligan;
 
 pub use card::{Card, CardCollection, CardFace, CardType};
 pub use deck::{Deck, Quantities};
+pub use draft::{Draft, DraftPack, DraftPick};
 pub use mana::{Color, Cost, CostSymbol};
 pub use match_result::{MatchResult, MatchResultBuilder, MatchResultBuilderError};
 pub use mtga_match::{MTGAMatch, MTGAMatchBuilder, MTGAMatchBuilderError};

--- a/arenabuddy/arenabuddy_core/src/mtga_events/business.rs
+++ b/arenabuddy/arenabuddy_core/src/mtga_events/business.rs
@@ -2,6 +2,8 @@ use chrono::Utc;
 use serde::{Deserialize, Deserializer, Serialize, de::Error};
 use serde_json::Value;
 
+use crate::mtga_events::primitives::ArenaId;
+
 /// Structs for MTGA "Business" events
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -41,10 +43,10 @@ pub struct DraftPackInfoEvent {
     pub draft_id: String,
     pub event_id: String,
     pub seat_number: i32,
-    pub pack_number: i32,
-    pub pick_number: i32,
-    pub pick_grp_id: i32,
-    pub cards_in_pack: Vec<i32>,
+    pub pack_number: u8,
+    pub pick_number: u8,
+    pub pick_grp_id: ArenaId,
+    pub cards_in_pack: Vec<ArenaId>,
     pub auto_pick: bool,
     pub time_remaining_on_pick: f64,
     pub event_type: i32,
@@ -57,7 +59,7 @@ pub struct DraftPackInfoEvent {
 #[serde(rename_all = "PascalCase")]
 pub struct DraftPickEvent {
     pub draft_id: String,
-    pub grp_ids: Vec<u32>,
+    pub grp_ids: Vec<ArenaId>,
     pub pack: u8,
     pub pick: u8,
 }

--- a/arenabuddy/arenabuddy_data/src/db/repository.rs
+++ b/arenabuddy/arenabuddy_data/src/db/repository.rs
@@ -1,5 +1,5 @@
 use arenabuddy_core::{
-    models::{Deck, MTGAMatch, MatchResult, Mulligan},
+    models::{Deck, Draft, MTGAMatch, MatchResult, Mulligan},
     replay::MatchReplay,
 };
 
@@ -14,6 +14,7 @@ pub trait ArenabuddyRepository: Send + Sync + 'static {
     fn list_decklists(&mut self, match_id: &str) -> impl Future<Output = Result<Vec<Deck>>> + Send;
     fn list_mulligans(&mut self, match_id: &str) -> impl Future<Output = Result<Vec<Mulligan>>> + Send;
     fn list_match_results(&mut self, match_id: &str) -> impl Future<Output = Result<Vec<MatchResult>>> + Send;
+    fn list_drafts(&mut self) -> impl Future<Output = Result<Vec<Draft>>> + Send;
 }
 
 impl<AR> ReplayStorage for AR


### PR DESCRIPTION
### TL;DR

Added draft tracking functionality to capture and process MTGA draft events.

### What changed?

- Created a new `draft.rs` module with `MTGADraft` and `DraftBuilder` structures to track draft events
- Added model definitions for `Draft`, `DraftPack`, and `DraftPick` in a new `models/draft.rs` file
- Refactored the `IngestionEvent` enum to consolidate draft-related business events
- Updated the `LogIngestionService` to use the new `DraftBuilder` for processing draft events
- Added draft-related database functionality to the Postgres repository implementation
- Modified the repository interface to support listing drafts
