### PR TITLE
[arenabuddy_core] Implement draft tracking and storage

### DIFF
--- a/.sqlx/query-07d3e8b63eb2eb2e82517019decca37eeae83bfb24e569ecdcceb1603e2b2204.json
+++ b/.sqlx/query-07d3e8b63eb2eb2e82517019decca37eeae83bfb24e569ecdcceb1603e2b2204.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO draft(id, set_code, draft_format, status, created_at)\n            VALUES ($1, $2, $3, $4, $5)\n            ON CONFLICT (id)\n            DO UPDATE SET set_code = excluded.set_code, draft_format = excluded.draft_format, status = excluded.status, created_at = excluded.created_at\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "07d3e8b63eb2eb2e82517019decca37eeae83bfb24e569ecdcceb1603e2b2204"
+}

--- a/.sqlx/query-bad83770dc2cb2547304bb3528697f084c96bb7a4aff2e2a311896767f77cb60.json
+++ b/.sqlx/query-bad83770dc2cb2547304bb3528697f084c96bb7a4aff2e2a311896767f77cb60.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO draft_pack(draft_id, pack_number, pick_number, cards, card_id, created_at)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            ON CONFLICT (draft_id, pack_number, pick_number)\n            DO UPDATE SET cards = excluded.cards, card_id = excluded.card_id\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Int4",
+        "Text",
+        "Int4",
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bad83770dc2cb2547304bb3528697f084c96bb7a4aff2e2a311896767f77cb60"
+}

--- a/arenabuddy/arenabuddy_core/src/draft.rs
+++ b/arenabuddy/arenabuddy_core/src/draft.rs
@@ -1,78 +1,129 @@
-#![expect(dead_code)]
 #![expect(clippy::similar_names)]
-use derive_builder::Builder;
+use uuid::Uuid;
 
 use crate::{
-    models::Draft,
+    Error, Result,
+    ingest::DraftWriter,
+    models::{Draft, DraftPack, MTGADraft},
     mtga_events::{
         business::{BusinessEvent, DraftPackInfoEvent},
-        draft::RequestTypeDraftNotify,
         primitives::ArenaId,
     },
 };
-
-#[derive(Debug, Builder)]
-pub struct MTGADraft {
-    draft: Draft,
-    packs: Vec<(RawPack, RawPick)>,
-}
 
 #[derive(Debug, Clone)]
 struct RawPack {
     pack_number: u8,
     pick_number: u8,
+    card_id: ArenaId,
     cards: Vec<ArenaId>,
 }
 
-#[derive(Debug, Clone)]
-struct RawPick {
-    card_id: ArenaId,
-    pick_time_seconds: f64,
-}
+#[derive(Debug)]
+struct PackPick(u8, u8);
 
-pub struct DraftBuilder {
-    builder: MTGADraftBuilder,
-}
-
-impl Default for DraftBuilder {
-    fn default() -> Self {
-        Self::new()
+impl PackPick {
+    pub fn is_last(&self) -> bool {
+        self.0 == 3 && self.1 == 13
     }
+}
+
+#[derive(Default)]
+pub struct DraftBuilder {
+    draft_id: Option<Uuid>,
+    event_id: Option<String>,
+    packs: Vec<RawPack>,
+
+    writers: Vec<Box<dyn DraftWriter>>,
 }
 
 impl DraftBuilder {
     pub fn new() -> Self {
-        Self {
-            builder: MTGADraftBuilder::default(),
-        }
+        Self::default()
     }
 
-    // not sure if this is needed yet
-    pub fn process_notify_event(&mut self, _event: &RequestTypeDraftNotify) {}
-
-    pub fn process_business_event(&mut self, event: &BusinessEvent) {
+    /// Consumes a business event and extracts relevant draft information
+    /// If a draft is finished (i.e. after pack3-pick13) results will be written to any
+    /// configured writers
+    ///
+    /// # Errors
+    /// errors if there is an issue writing the draft results to storage
+    pub async fn process_business_event(&mut self, event: &BusinessEvent) -> Result<()> {
         if let BusinessEvent::Draft(e) = event {
-            self.process_pack_event(e);
+            let pp = self.process_pack_event(e);
+            self.write_draft(pp).await?;
         }
+        Ok(())
     }
 
-    fn process_pack_event(&mut self, draft_pack_info_event: &DraftPackInfoEvent) {
-        let pick = RawPick {
-            card_id: draft_pack_info_event.pick_grp_id,
-            pick_time_seconds: draft_pack_info_event.time_remaining_on_pick,
-        };
+    fn process_pack_event(&mut self, draft_pack_info_event: &DraftPackInfoEvent) -> PackPick {
+        self.draft_id = draft_pack_info_event.draft_id.parse::<Uuid>().ok();
+        self.event_id = Some(draft_pack_info_event.event_id.clone());
 
         let pack = RawPack {
             cards: draft_pack_info_event.cards_in_pack.clone(),
+            card_id: draft_pack_info_event.pick_grp_id,
             pack_number: draft_pack_info_event.pack_number,
             pick_number: draft_pack_info_event.pick_number,
         };
 
         tracingx::info!("Pack #{}, Pick #{}", pack.pack_number, pack.pick_number);
-        if let Some(packs) = self.builder.packs.as_mut() {
-            packs.push((pack, pick));
-        } else {
-            self.builder.packs = Some(vec![(pack, pick)]);
-        }
+        let last_pack = pack.pack_number;
+        let last_pick = pack.pick_number;
+        self.packs.push(pack);
+        PackPick(last_pack, last_pick)
     }
+
+    async fn write_draft(&mut self, pp: PackPick) -> Result<()> {
+        if !pp.is_last() {
+            return Ok(());
+        }
+
+        if let (Some(draft_id), Some(event_id)) = (self.draft_id, &self.event_id) {
+            let (format, set_code) = parse_event_id(event_id);
+            let draft = Draft::new(draft_id, set_code, format, String::new());
+            let packs: Vec<_> = self
+                .packs
+                .iter()
+                .map(|pack| {
+                    DraftPack::new(
+                        draft_id,
+                        pack.pack_number,
+                        pack.pick_number,
+                        pack.card_id,
+                        pack.cards.clone(),
+                    )
+                })
+                .collect();
+
+            let mtga_draft = MTGADraft::new(draft, packs);
+
+            for writer in &mut self.writers {
+                writer.write(&mtga_draft).await?;
+            }
+            self.reset();
+            return Ok(());
+        }
+        Err(Error::Io("can't locate draft_id or event_id".to_string()))
+    }
+
+    pub fn add_writer(&mut self, writer: Box<dyn DraftWriter>) {
+        self.writers.push(writer);
+    }
+
+    fn reset(&mut self) {
+        self.packs.clear();
+        self.draft_id = None;
+        self.event_id = None;
+    }
+}
+
+/// returns draft format and set code if found
+fn parse_event_id(event_id: &str) -> (String, String) {
+    let parts: Vec<_> = event_id.split('_').collect();
+    if parts.len() != 3 {
+        return (String::new(), String::new());
+    }
+
+    (parts[0].to_string(), parts[1].to_string())
 }

--- a/arenabuddy/arenabuddy_core/src/models/draft.rs
+++ b/arenabuddy/arenabuddy_core/src/models/draft.rs
@@ -5,6 +5,26 @@ use uuid::Uuid;
 
 use crate::mtga_events::primitives::ArenaId;
 
+#[derive(Debug)]
+pub struct MTGADraft {
+    draft: Draft,
+    packs: Vec<DraftPack>,
+}
+
+impl MTGADraft {
+    pub fn new(draft: Draft, packs: Vec<DraftPack>) -> Self {
+        Self { draft, packs }
+    }
+
+    pub fn draft(&self) -> &Draft {
+        &self.draft
+    }
+
+    pub fn packs(&self) -> &[DraftPack] {
+        &self.packs
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Draft {
     id: Uuid,
@@ -15,14 +35,40 @@ pub struct Draft {
 }
 
 impl Draft {
-    pub fn new(id: Uuid, set_code: String, format: String, status: String, created_at: DateTime<Utc>) -> Self {
+    pub fn new(id: Uuid, set_code: String, format: String, status: String) -> Self {
         Self {
             id,
             set_code,
             format,
             status,
-            created_at,
+            created_at: Utc::now(),
         }
+    }
+
+    #[must_use]
+    pub fn with_created_at(mut self, and_utc: DateTime<Utc>) -> Draft {
+        self.created_at = and_utc;
+        self
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn set_code(&self) -> &str {
+        &self.set_code
+    }
+
+    pub fn format(&self) -> &str {
+        &self.format
+    }
+
+    pub fn status(&self) -> &str {
+        &self.status
+    }
+
+    pub fn created_at(&self) -> &DateTime<Utc> {
+        &self.created_at
     }
 }
 
@@ -32,53 +78,37 @@ pub struct DraftPack {
     draft_id: Uuid,
     pack_number: u8,
     pick_number: u8,
+    card_id: ArenaId,
     cards: Vec<ArenaId>,
     created_at: DateTime<Utc>,
 }
 
 impl DraftPack {
-    pub fn new(
-        id: u64,
-        draft_id: Uuid,
-        pack_number: u8,
-        pick_number: u8,
-        cards: Vec<ArenaId>,
-        created_at: DateTime<Utc>,
-    ) -> Self {
+    pub fn new(draft_id: Uuid, pack_number: u8, pick_number: u8, card_id: ArenaId, cards: Vec<ArenaId>) -> Self {
         Self {
-            id,
+            id: 0,
             draft_id,
             pack_number,
             pick_number,
+            card_id,
             cards,
-            created_at,
+            created_at: Utc::now(),
         }
     }
-}
 
-#[derive(Debug, Clone)]
-pub struct DraftPick {
-    id: u64,
-    draft_pack_id: u64,
-    card_id: ArenaId,
-    pick_time_seconds: f64,
-    created_at: DateTime<Utc>,
-}
+    pub fn pack_number(&self) -> u8 {
+        self.pack_number
+    }
 
-impl DraftPick {
-    pub fn new(
-        id: u64,
-        draft_pack_id: u64,
-        card_id: ArenaId,
-        pick_time_seconds: f64,
-        created_at: DateTime<Utc>,
-    ) -> Self {
-        Self {
-            id,
-            draft_pack_id,
-            card_id,
-            pick_time_seconds,
-            created_at,
-        }
+    pub fn pick_number(&self) -> u8 {
+        self.pick_number
+    }
+
+    pub fn picked_card(&self) -> ArenaId {
+        self.card_id
+    }
+
+    pub fn cards(&self) -> &[ArenaId] {
+        &self.cards
     }
 }

--- a/arenabuddy/arenabuddy_core/src/models/mod.rs
+++ b/arenabuddy/arenabuddy_core/src/models/mod.rs
@@ -8,7 +8,7 @@ mod mulligan;
 
 pub use card::{Card, CardCollection, CardFace, CardType};
 pub use deck::{Deck, Quantities};
-pub use draft::{Draft, DraftPack, DraftPick};
+pub use draft::{Draft, DraftPack, MTGADraft};
 pub use mana::{Color, Cost, CostSymbol};
 pub use match_result::{MatchResult, MatchResultBuilder, MatchResultBuilderError};
 pub use mtga_match::{MTGAMatch, MTGAMatchBuilder, MTGAMatchBuilderError};

--- a/arenabuddy/arenabuddy_core/src/mtga_events/primitives.rs
+++ b/arenabuddy/arenabuddy_core/src/mtga_events/primitives.rs
@@ -7,6 +7,12 @@ use crate::mtga_events::gre::Reference;
 #[derive(Default, Debug, Clone, PartialEq, PartialOrd, Copy, Eq, Ord)]
 pub struct ArenaId(i32);
 
+impl ArenaId {
+    pub fn inner(&self) -> i32 {
+        self.0
+    }
+}
+
 impl Serialize for ArenaId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/arenabuddy/arenabuddy_data/migrations/postgres/20250907002910_draft_tables_amend.sql
+++ b/arenabuddy/arenabuddy_data/migrations/postgres/20250907002910_draft_tables_amend.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS draft_pick;
+
+ALTER TABLE draft_pack ADD COLUMN card_id INTEGER NOT NULL;


### PR DESCRIPTION
# Implement Draft Tracking and Storage

This PR adds functionality to track and store MTG Arena draft sessions. Key changes include:

- Implemented `DraftBuilder` to process draft events and construct complete draft records
- Added `DraftWriter` trait for storing draft data
- Enhanced `MTGADraft` model to represent complete draft sessions
- Updated database schema to store draft picks with corresponding card IDs
- Integrated draft tracking into the log ingestion service
- Added draft storage support to the PostgreSQL database implementation

The system now captures each pack and pick during a draft session, storing the complete draft history once the final pick is made. This enables future analysis of draft patterns and pick decisions.