### PR TITLE
Add match classification service with archetype detection and local caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ version = "0.1.0"
 dependencies = [
  "arenabuddy_core",
  "arenabuddy_data",
+ "arenabuddy_metagame",
  "base64 0.22.1",
  "chrono",
  "google-sheets4",

--- a/arenabuddy/arenabuddy/src/backend/grpc_writer.rs
+++ b/arenabuddy/arenabuddy/src/backend/grpc_writer.rs
@@ -2,8 +2,9 @@ use arenabuddy_core::{
     cards::CardsDatabase,
     models::{MTGAMatch, MatchData, MatchResult, OpponentDeck},
     player_log::replay::MatchReplay,
-    services::match_service::{UpsertMatchDataRequest, match_service_client::MatchServiceClient},
+    services::match_service::{ClassifyMatchRequest, UpsertMatchDataRequest, match_service_client::MatchServiceClient},
 };
+use arenabuddy_data::{MatchDB, MetagameRepository, metagame_models::MatchArchetype};
 use chrono::Utc;
 use tonic::transport::Channel;
 use tracingx::{error, info};
@@ -15,6 +16,7 @@ pub struct GrpcReplayWriter {
     cards: CardsDatabase,
     auth_state: SharedAuthState,
     grpc_url: String,
+    local_db: MatchDB,
 }
 
 impl GrpcReplayWriter {
@@ -22,6 +24,7 @@ impl GrpcReplayWriter {
         url: &str,
         cards: CardsDatabase,
         auth_state: SharedAuthState,
+        local_db: MatchDB,
     ) -> Result<Self, tonic::transport::Error> {
         let client = MatchServiceClient::connect(url.to_string()).await?;
         Ok(Self {
@@ -29,6 +32,7 @@ impl GrpcReplayWriter {
             cards,
             auth_state,
             grpc_url: url.to_string(),
+            local_db,
         })
     }
 
@@ -76,14 +80,57 @@ impl GrpcReplayWriter {
             }
         };
 
-        let request = build_request(match_data, Some(new_token));
+        let request = build_request(match_data, Some(new_token.clone()));
         self.client.upsert_match_data(request).await.map_err(|e| {
             error!("gRPC retry failed for match {match_id}: {e}");
             arenabuddy_core::Error::Io(format!("gRPC retry failed: {e}"))
         })?;
 
         info!("Sent match {match_id} to gRPC backend (after refresh)");
+        self.classify_and_cache(match_id, Some(new_token)).await;
         Ok(())
+    }
+
+    /// Request classification from the server and cache results locally.
+    /// Best-effort: errors are logged but not propagated.
+    async fn classify_and_cache(&mut self, match_id: &str, token: Option<String>) {
+        let mut request = tonic::Request::new(ClassifyMatchRequest {
+            match_id: match_id.to_string(),
+        });
+
+        if let Some(token) = token {
+            let bearer = format!("Bearer {token}");
+            if let Ok(value) = bearer.parse() {
+                request.metadata_mut().insert("authorization", value);
+            }
+        }
+
+        match self.client.classify_match(request).await {
+            Ok(response) => {
+                let classifications = response.into_inner().classifications;
+                for c in &classifications {
+                    let ma = MatchArchetype {
+                        match_id: match_id.to_string(),
+                        side: c.side.clone(),
+                        archetype_id: None,
+                        archetype_name: c.archetype_name.clone(),
+                        confidence: c.confidence,
+                    };
+                    if let Err(e) = self.local_db.upsert_match_archetype(&ma).await {
+                        error!("Failed to cache archetype for match {match_id}: {e}");
+                    }
+                }
+                if !classifications.is_empty() {
+                    info!(
+                        "Cached {} archetype classification(s) for match {match_id}",
+                        classifications.len()
+                    );
+                }
+            }
+            Err(e) => {
+                error!("Classification request failed for match {match_id}: {e}");
+            }
+        }
     }
 }
 
@@ -134,11 +181,12 @@ impl arenabuddy_core::player_log::ingest::ReplayWriter for GrpcReplayWriter {
         };
 
         let token = self.current_token().await;
-        let request = build_request(&match_data, token);
+        let request = build_request(&match_data, token.clone());
 
         match self.client.upsert_match_data(request).await {
             Ok(_) => {
                 info!("Sent match {match_id} to gRPC backend");
+                self.classify_and_cache(&match_id, token).await;
                 Ok(())
             }
             Err(e) if e.code() == tonic::Code::Unauthenticated => {

--- a/arenabuddy/arenabuddy/src/backend/ingest.rs
+++ b/arenabuddy/arenabuddy/src/backend/ingest.rs
@@ -123,6 +123,7 @@ pub async fn start(
     };
 
     // Add database writer
+    let grpc_local_db = db.clone();
     let service = service.add_writer(Box::new(db.clone())).add_draft_writer(Box::new(db));
 
     // Add directory storage writer (handles None internally via the adapter)
@@ -133,7 +134,7 @@ pub async fn start(
     let mut debug_reporter: Option<Arc<Mutex<DebugReporter>>> = None;
     let grpc_url = super::paths::grpc_url();
     let service = {
-        match GrpcReplayWriter::connect(&grpc_url, cards, auth_state.clone()).await {
+        match GrpcReplayWriter::connect(&grpc_url, cards, auth_state.clone(), grpc_local_db).await {
             Ok(writer) => {
                 info!("Connected to gRPC backend at {grpc_url}");
 

--- a/arenabuddy/core/proto/arenabuddy/api/v1/match_service.proto
+++ b/arenabuddy/core/proto/arenabuddy/api/v1/match_service.proto
@@ -32,6 +32,20 @@ message DeleteMatchRequest {
 
 message DeleteMatchResponse {}
 
+message ClassifyMatchRequest {
+  string match_id = 1;
+}
+
+message ArchetypeClassification {
+  string side = 1;           // "controller" or "opponent"
+  string archetype_name = 2;
+  float confidence = 3;
+}
+
+message ClassifyMatchResponse {
+  repeated ArchetypeClassification classifications = 1;
+}
+
 // --- Service ---
 
 service MatchService {
@@ -39,4 +53,5 @@ service MatchService {
   rpc GetMatchData(GetMatchDataRequest) returns (GetMatchDataResponse);
   rpc ListMatches(ListMatchesRequest) returns (ListMatchesResponse);
   rpc DeleteMatch(DeleteMatchRequest) returns (DeleteMatchResponse);
+  rpc ClassifyMatch(ClassifyMatchRequest) returns (ClassifyMatchResponse);
 }

--- a/arenabuddy/core/src/services/match_service.rs
+++ b/arenabuddy/core/src/services/match_service.rs
@@ -1,4 +1,5 @@
 pub use crate::proto::arenabuddy::api::v1::{
-    DeleteMatchRequest, DeleteMatchResponse, GetMatchDataRequest, GetMatchDataResponse, ListMatchesRequest,
-    ListMatchesResponse, UpsertMatchDataRequest, UpsertMatchDataResponse, match_service_client, match_service_server,
+    ArchetypeClassification, ClassifyMatchRequest, ClassifyMatchResponse, DeleteMatchRequest, DeleteMatchResponse,
+    GetMatchDataRequest, GetMatchDataResponse, ListMatchesRequest, ListMatchesResponse, UpsertMatchDataRequest,
+    UpsertMatchDataResponse, match_service_client, match_service_server,
 };

--- a/arenabuddy/metagame/src/classification.rs
+++ b/arenabuddy/metagame/src/classification.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use arenabuddy_data::{
     MetagameRepository,
-    metagame_models::{MatchArchetype, SignatureCard},
+    metagame_models::{MatchArchetype, SignatureCard, SignatureCardRow},
 };
 use tracing::info;
 
@@ -15,6 +15,32 @@ const MIN_CLASSIFICATION_SCORE: f32 = 0.5;
 
 /// Expected number of cards in a standard deck (used for confidence scaling).
 const EXPECTED_DECK_SIZE: f32 = 60.0;
+
+/// Type alias for the card-to-archetype lookup map.
+pub type CardLookup = HashMap<String, Vec<(i32, String, f32)>>;
+
+/// Build a lookup map from card names to their archetype associations.
+pub fn build_card_lookup(signature_cards: &[SignatureCardRow]) -> CardLookup {
+    let mut lookup: CardLookup = HashMap::new();
+    for sc in signature_cards {
+        lookup
+            .entry(sc.card_name.clone())
+            .or_default()
+            .push((sc.archetype_id, sc.archetype_name.clone(), sc.weight));
+    }
+    lookup
+}
+
+/// Map an MTGA event ID to the metagame format name used for signature cards.
+pub fn event_id_to_format(event_id: &str) -> Option<&'static str> {
+    match event_id {
+        "Ladder" | "Traditional_Ladder" => Some("standard"),
+        "Explorer_Ladder" | "Traditional_Explorer_Ladder" => Some("explorer"),
+        "Historic_Ladder" | "Traditional_Historic_Ladder" => Some("historic"),
+        "Timeless_Ladder" | "Traditional_Timeless_Ladder" => Some("timeless"),
+        _ => None,
+    }
+}
 
 /// Compute signature cards for all archetypes in a given format.
 ///
@@ -70,10 +96,6 @@ pub async fn compute_signature_cards(repo: &impl MetagameRepository, format: &st
 }
 
 /// Classify all unclassified matches in a given format using signature cards.
-///
-/// For each match, maps the controller and opponent decks' card names
-/// against known signature cards, scoring each archetype by the sum of
-/// matching signature card weights.
 pub async fn classify_matches(repo: &impl MetagameRepository, format: &str) -> Result<u64> {
     let signature_cards = repo.get_signature_cards(format).await?;
     if signature_cards.is_empty() {
@@ -81,15 +103,7 @@ pub async fn classify_matches(repo: &impl MetagameRepository, format: &str) -> R
         return Ok(0);
     }
 
-    // Build lookup: card_name -> Vec<(archetype_id, archetype_name, weight)>
-    let mut card_to_archetypes: HashMap<String, Vec<(i32, String, f32)>> = HashMap::new();
-    for sc in &signature_cards {
-        card_to_archetypes.entry(sc.card_name.clone()).or_default().push((
-            sc.archetype_id,
-            sc.archetype_name.clone(),
-            sc.weight,
-        ));
-    }
+    let card_to_archetypes = build_card_lookup(&signature_cards);
 
     let unclassified = repo.get_unclassified_matches(format).await?;
     info!("Found {} unclassified matches for {format}", unclassified.len());
@@ -98,38 +112,7 @@ pub async fn classify_matches(repo: &impl MetagameRepository, format: &str) -> R
 
     for m in &unclassified {
         let match_id = m.match_id.to_string();
-
-        // Classify controller deck
-        let controller_cards = repo.get_match_deck_cards(&match_id).await?;
-        if let Some(archetype) = score_deck(&controller_cards, &card_to_archetypes, 1.0) {
-            repo.upsert_match_archetype(&MatchArchetype {
-                match_id: match_id.clone(),
-                side: "controller".to_string(),
-                archetype_id: Some(archetype.0),
-                archetype_name: archetype.1.clone(),
-                confidence: archetype.2,
-            })
-            .await?;
-        }
-
-        // Classify opponent deck
-        let opponent_cards = repo.get_match_opponent_cards(&match_id).await?;
-        if !opponent_cards.is_empty() {
-            // Scale confidence by how complete the opponent deck observation is
-            #[expect(clippy::cast_precision_loss)]
-            let completeness = (opponent_cards.len() as f32 / EXPECTED_DECK_SIZE).min(1.0);
-            if let Some(archetype) = score_deck(&opponent_cards, &card_to_archetypes, completeness) {
-                repo.upsert_match_archetype(&MatchArchetype {
-                    match_id: match_id.clone(),
-                    side: "opponent".to_string(),
-                    archetype_id: Some(archetype.0),
-                    archetype_name: archetype.1.clone(),
-                    confidence: archetype.2,
-                })
-                .await?;
-            }
-        }
-
+        classify_and_store(repo, &match_id, &card_to_archetypes).await?;
         classified_count += 1;
     }
 
@@ -137,11 +120,79 @@ pub async fn classify_matches(repo: &impl MetagameRepository, format: &str) -> R
     Ok(classified_count)
 }
 
+/// Classify a single match on-the-fly and return the results.
+///
+/// Loads signature cards for the match's format, scores the controller and opponent
+/// decks, stores results in the database, and returns the classifications.
+/// Returns an empty vec if no signature cards exist or the format is unknown.
+pub async fn classify_single_match(
+    repo: &impl MetagameRepository,
+    match_id: &str,
+    mtga_format: &str,
+) -> Result<Vec<MatchArchetype>> {
+    let Some(format) = event_id_to_format(mtga_format) else {
+        info!("Unknown MTGA format '{mtga_format}', skipping classification");
+        return Ok(Vec::new());
+    };
+
+    let signature_cards = repo.get_signature_cards(format).await?;
+    if signature_cards.is_empty() {
+        info!("No signature cards for {format}, skipping classification");
+        return Ok(Vec::new());
+    }
+
+    let card_to_archetypes = build_card_lookup(&signature_cards);
+    classify_and_store(repo, match_id, &card_to_archetypes).await
+}
+
+/// Score and store classifications for a single match. Returns the stored archetypes.
+async fn classify_and_store(
+    repo: &impl MetagameRepository,
+    match_id: &str,
+    card_to_archetypes: &CardLookup,
+) -> Result<Vec<MatchArchetype>> {
+    let mut results = Vec::new();
+
+    // Classify controller deck
+    let controller_cards = repo.get_match_deck_cards(match_id).await?;
+    if let Some(archetype) = score_deck(&controller_cards, card_to_archetypes, 1.0) {
+        let ma = MatchArchetype {
+            match_id: match_id.to_string(),
+            side: "controller".to_string(),
+            archetype_id: Some(archetype.0),
+            archetype_name: archetype.1.clone(),
+            confidence: archetype.2,
+        };
+        repo.upsert_match_archetype(&ma).await?;
+        results.push(ma);
+    }
+
+    // Classify opponent deck
+    let opponent_cards = repo.get_match_opponent_cards(match_id).await?;
+    if !opponent_cards.is_empty() {
+        #[expect(clippy::cast_precision_loss)]
+        let completeness = (opponent_cards.len() as f32 / EXPECTED_DECK_SIZE).min(1.0);
+        if let Some(archetype) = score_deck(&opponent_cards, card_to_archetypes, completeness) {
+            let ma = MatchArchetype {
+                match_id: match_id.to_string(),
+                side: "opponent".to_string(),
+                archetype_id: Some(archetype.0),
+                archetype_name: archetype.1.clone(),
+                confidence: archetype.2,
+            };
+            repo.upsert_match_archetype(&ma).await?;
+            results.push(ma);
+        }
+    }
+
+    Ok(results)
+}
+
 /// Score a deck's cards against signature card data.
 /// Returns the best matching archetype as `(archetype_id, archetype_name, confidence)`.
-fn score_deck(
+pub fn score_deck(
     card_names: &[String],
-    card_to_archetypes: &HashMap<String, Vec<(i32, String, f32)>>,
+    card_to_archetypes: &CardLookup,
     confidence_scale: f32,
 ) -> Option<(i32, String, f32)> {
     let mut archetype_scores: HashMap<i32, (String, f32)> = HashMap::new();
@@ -177,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_score_deck_finds_best_match() {
-        let mut card_to_archetypes: HashMap<String, Vec<(i32, String, f32)>> = HashMap::new();
+        let mut card_to_archetypes: CardLookup = HashMap::new();
         card_to_archetypes.insert("Lightning Bolt".to_string(), vec![(1, "Mono Red".to_string(), 0.8)]);
         card_to_archetypes.insert(
             "Monastery Swiftspear".to_string(),
@@ -200,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_score_deck_below_threshold() {
-        let mut card_to_archetypes: HashMap<String, Vec<(i32, String, f32)>> = HashMap::new();
+        let mut card_to_archetypes: CardLookup = HashMap::new();
         card_to_archetypes.insert("Mountain".to_string(), vec![(1, "Mono Red".to_string(), 0.1)]);
 
         let deck = vec!["Mountain".to_string()];
@@ -211,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_score_deck_confidence_scaling() {
-        let mut card_to_archetypes: HashMap<String, Vec<(i32, String, f32)>> = HashMap::new();
+        let mut card_to_archetypes: CardLookup = HashMap::new();
         card_to_archetypes.insert("Lightning Bolt".to_string(), vec![(1, "Mono Red".to_string(), 0.8)]);
         card_to_archetypes.insert(
             "Monastery Swiftspear".to_string(),
@@ -224,5 +275,13 @@ mod tests {
         let partial = score_deck(&deck, &card_to_archetypes, 0.25).unwrap();
 
         assert!(partial.2 < full.2);
+    }
+
+    #[test]
+    fn test_event_id_to_format() {
+        assert_eq!(event_id_to_format("Ladder"), Some("standard"));
+        assert_eq!(event_id_to_format("Traditional_Ladder"), Some("standard"));
+        assert_eq!(event_id_to_format("Explorer_Ladder"), Some("explorer"));
+        assert_eq!(event_id_to_format("SomeRandomEvent"), None);
     }
 }

--- a/arenabuddy/server/Cargo.toml
+++ b/arenabuddy/server/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 arenabuddy_core = { path = "../core/" }
 arenabuddy_data = { path = "../data" }
+arenabuddy_metagame = { path = "../metagame" }
 base64 = { workspace = true }
 chrono = { workspace = true }
 google-sheets4 = { workspace = true }

--- a/arenabuddy/server/src/match_service.rs
+++ b/arenabuddy/server/src/match_service.rs
@@ -2,8 +2,9 @@ use arenabuddy_core::{
     cards::CardsDatabase,
     models::{ArenaId, MatchData, OpponentDeck},
     services::match_service::{
-        DeleteMatchRequest, DeleteMatchResponse, GetMatchDataRequest, GetMatchDataResponse, ListMatchesRequest,
-        ListMatchesResponse, UpsertMatchDataRequest, UpsertMatchDataResponse, match_service_server::MatchService,
+        ArchetypeClassification, ClassifyMatchRequest, ClassifyMatchResponse, DeleteMatchRequest, DeleteMatchResponse,
+        GetMatchDataRequest, GetMatchDataResponse, ListMatchesRequest, ListMatchesResponse, UpsertMatchDataRequest,
+        UpsertMatchDataResponse, match_service_server::MatchService,
     },
 };
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
@@ -166,5 +167,51 @@ impl MatchService for MatchServiceImpl {
 
         info!("Deleted match: {match_id}");
         Ok(Response::new(DeleteMatchResponse {}))
+    }
+
+    #[instrument(skip(self, request))]
+    async fn classify_match(
+        &self,
+        request: Request<ClassifyMatchRequest>,
+    ) -> Result<Response<ClassifyMatchResponse>, Status> {
+        let user_id = request.extensions().get::<UserId>().map(|u| u.0);
+        let match_id = request.into_inner().match_id;
+        if match_id.is_empty() {
+            return Err(Status::invalid_argument("match_id is required"));
+        }
+
+        // Get the match to determine its format
+        let (mtga_match, _) = self.db.get_match(&match_id, user_id).await.map_err(|e| {
+            error!("Failed to get match for classification: {e}");
+            Status::internal("failed to get match")
+        })?;
+
+        if mtga_match.id().is_empty() {
+            return Err(Status::not_found(format!("match not found: {match_id}")));
+        }
+
+        let Some(format) = mtga_match.format() else {
+            return Ok(Response::new(ClassifyMatchResponse {
+                classifications: vec![],
+            }));
+        };
+
+        let archetypes = arenabuddy_metagame::classification::classify_single_match(&self.db, &match_id, format)
+            .await
+            .map_err(|e| {
+                error!("Classification failed for match {match_id}: {e}");
+                Status::internal("classification failed")
+            })?;
+
+        let classifications = archetypes
+            .into_iter()
+            .map(|a| ArchetypeClassification {
+                side: a.side,
+                archetype_name: a.archetype_name,
+                confidence: a.confidence,
+            })
+            .collect();
+
+        Ok(Response::new(ClassifyMatchResponse { classifications }))
     }
 }


### PR DESCRIPTION
This pull request adds real-time archetype classification functionality to the match ingestion pipeline. When matches are uploaded via gRPC, the system now automatically requests archetype classifications from the server and caches the results locally.

**Key Changes:**

- Added `ClassifyMatch` RPC endpoint that analyzes deck compositions and returns archetype predictions with confidence scores
- Modified `GrpcReplayWriter` to automatically request classifications after successful match uploads and store results in the local database
- Extracted reusable classification logic including card lookup building and deck scoring functions
- Added `classify_single_match` function for on-demand archetype analysis of individual matches
- Enhanced the match service to support the new classification workflow with proper error handling

The classification system uses signature cards to identify archetypes by scoring deck compositions against known archetype patterns, with confidence scaling based on deck completeness for opponent decks.