### PR TITLE
Display archetype information in match details and deck lists

### DIFF
--- a/arenabuddy/arenabuddy/assets/tailwind.css
+++ b/arenabuddy/arenabuddy/assets/tailwind.css
@@ -34,6 +34,7 @@
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-900: oklch(37.9% 0.146 265.522);
     --color-indigo-900: oklch(35.9% 0.144 278.697);
+    --color-violet-200: oklch(89.4% 0.057 293.283);
     --color-violet-300: oklch(81.1% 0.111 293.571);
     --color-violet-600: oklch(54.1% 0.281 293.009);
     --color-violet-700: oklch(49.1% 0.27 292.581);
@@ -978,6 +979,9 @@
   }
   .text-red-400 {
     color: var(--color-red-400);
+  }
+  .text-violet-200 {
+    color: var(--color-violet-200);
   }
   .text-violet-300 {
     color: var(--color-violet-300);

--- a/arenabuddy/arenabuddy/src/app/components/deck_list.rs
+++ b/arenabuddy/arenabuddy/src/app/components/deck_list.rs
@@ -10,6 +10,7 @@ use crate::app::components::ManaCost;
 pub fn DeckList(
     deck: DeckDisplayRecord,
     #[props(optional)] title: Option<&'static str>,
+    #[props(optional)] archetype: Option<String>,
     #[props(default = true)] show_quantities: bool,
 ) -> Element {
     let title = title.unwrap_or("Your Deck");
@@ -20,6 +21,9 @@ pub fn DeckList(
         div { class: "bg-gray-800 rounded-lg border border-gray-700 overflow-hidden",
             div { class: "bg-gradient-to-r from-violet-800 to-indigo-900 py-4 px-6",
                 h2 { class: "text-xl font-bold text-white", "{title}" }
+                if let Some(ref archetype) = archetype {
+                    p { class: "text-sm text-violet-200 mt-1", "{archetype}" }
+                }
             }
             div { class: "p-6",
                 div { class: "deck-content",

--- a/arenabuddy/arenabuddy/src/app/components/match_info.rs
+++ b/arenabuddy/arenabuddy/src/app/components/match_info.rs
@@ -7,6 +7,8 @@ pub fn MatchInfo(
     opponent_player_name: String,
     did_controller_win: bool,
     format: Option<String>,
+    #[props(optional)] controller_archetype: Option<String>,
+    #[props(optional)] opponent_archetype: Option<String>,
 ) -> Element {
     let display_format = format.as_deref().map_or("Unknown", format_event_id);
 
@@ -22,10 +24,20 @@ pub fn MatchInfo(
                         div { class: "bg-blue-900/20 p-3 rounded-md",
                             span { class: "font-semibold", "You" }
                             " {controller_player_name}"
+                            if let Some(ref archetype) = controller_archetype {
+                                span { class: "ml-2 px-2 py-0.5 text-xs rounded-full bg-violet-900/40 text-violet-300",
+                                    "{archetype}"
+                                }
+                            }
                         }
                         div { class: "bg-red-900/20 p-3 rounded-md",
                             span { class: "font-semibold", "Opponent" }
                             " {opponent_player_name}"
+                            if let Some(ref archetype) = opponent_archetype {
+                                span { class: "ml-2 px-2 py-0.5 text-xs rounded-full bg-violet-900/40 text-violet-300",
+                                    "{archetype}"
+                                }
+                            }
                         }
                     }
                 }

--- a/arenabuddy/arenabuddy/src/app/match_details.rs
+++ b/arenabuddy/arenabuddy/src/app/match_details.rs
@@ -110,12 +110,17 @@ pub(crate) fn MatchDetails(id: String) -> Element {
                     let mut active_tab = use_signal(|| 0u8);
                     let event_count: usize = details.event_logs.iter().map(|l| l.events.len()).sum();
 
+                    let controller_archetype = details.controller_archetype.clone();
+                    let opponent_archetype = details.opponent_archetype.clone();
+
                     rsx! {
                         MatchInfo {
                             controller_player_name: details.controller_player_name.clone(),
                             opponent_player_name: details.opponent_player_name.clone(),
                             did_controller_win: details.did_controller_win,
-                            format: details.format.clone()
+                            format: details.format.clone(),
+                            controller_archetype: details.controller_archetype.clone(),
+                            opponent_archetype: details.opponent_archetype.clone(),
                         }
 
                         div { class: "flex gap-1 mb-6 border-b border-gray-700",
@@ -149,6 +154,7 @@ pub(crate) fn MatchDetails(id: String) -> Element {
                                 if let Some(ref deck) = details.primary_decklist {
                                     DeckList {
                                         title: "Your deck",
+                                        archetype: controller_archetype.clone(),
                                         deck: deck.clone()
                                     }
                                 }
@@ -156,6 +162,7 @@ pub(crate) fn MatchDetails(id: String) -> Element {
                                 if let Some(ref opponent_deck) = details.opponent_deck {
                                     DeckList {
                                         title: "Opponent's cards",
+                                        archetype: opponent_archetype.clone(),
                                         deck: opponent_deck.clone(),
                                         show_quantities: false
                                     }

--- a/arenabuddy/arenabuddy/src/backend/service.rs
+++ b/arenabuddy/arenabuddy/src/backend/service.rs
@@ -13,7 +13,7 @@ use arenabuddy_core::{
     },
     models::Draft,
 };
-use arenabuddy_data::DirectoryStorage;
+use arenabuddy_data::{DirectoryStorage, MetagameRepository};
 use tokio::sync::Mutex;
 use tracingx::{error, info};
 
@@ -32,7 +32,7 @@ pub struct AppService<D: arenabuddy_data::ArenabuddyRepository> {
 
 impl<D> std::fmt::Debug for AppService<D>
 where
-    D: arenabuddy_data::ArenabuddyRepository,
+    D: arenabuddy_data::ArenabuddyRepository + MetagameRepository,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AppService")
@@ -46,7 +46,7 @@ where
 
 impl<D> AppService<D>
 where
-    D: arenabuddy_data::ArenabuddyRepository,
+    D: arenabuddy_data::ArenabuddyRepository + MetagameRepository,
 {
     pub fn new(
         db: D,
@@ -139,6 +139,10 @@ where
             error!("Error retrieving event logs: {}", e);
             Vec::default()
         });
+
+        let (controller_archetype, opponent_archetype) = self.db.get_match_archetypes(&id).await.unwrap_or_default();
+        match_details.controller_archetype = controller_archetype;
+        match_details.opponent_archetype = opponent_archetype;
 
         Ok(match_details)
     }

--- a/arenabuddy/core/src/display/match_details.rs
+++ b/arenabuddy/core/src/display/match_details.rs
@@ -26,4 +26,6 @@ pub struct MatchDetails {
     pub opponent_deck: Option<DeckDisplayRecord>,
     pub mulligans: Vec<Mulligan>,
     pub event_logs: Vec<GameEventLog>,
+    pub controller_archetype: Option<String>,
+    pub opponent_archetype: Option<String>,
 }

--- a/arenabuddy/data/src/db/metagame_postgres.rs
+++ b/arenabuddy/data/src/db/metagame_postgres.rs
@@ -1,4 +1,4 @@
-use sqlx::types::Uuid;
+use sqlx::{FromRow, types::Uuid};
 
 use super::{
     metagame_models::{
@@ -9,6 +9,12 @@ use super::{
     postgres::PostgresMatchDB,
 };
 use crate::Result;
+
+#[derive(FromRow)]
+struct MatchArchetypeRow {
+    side: String,
+    archetype_name: String,
+}
 
 #[async_trait::async_trait]
 impl MetagameRepository for PostgresMatchDB {
@@ -298,5 +304,27 @@ impl MetagameRepository for PostgresMatchDB {
         let arena_ids: Vec<i32> = serde_json::from_str(&row.0).unwrap_or_default();
         let card_names = self.arena_ids_to_card_names(&arena_ids);
         Ok(card_names)
+    }
+
+    async fn get_match_archetypes(&self, match_id: &str) -> Result<(Option<String>, Option<String>)> {
+        let match_uuid = Uuid::parse_str(match_id)?;
+
+        let rows: Vec<MatchArchetypeRow> =
+            sqlx::query_as("SELECT side, archetype_name FROM match_archetype WHERE match_id = $1")
+                .bind(match_uuid)
+                .fetch_all(self.pool())
+                .await?;
+
+        let mut controller = None;
+        let mut opponent = None;
+        for row in rows {
+            match row.side.as_str() {
+                "controller" => controller = Some(row.archetype_name),
+                "opponent" => opponent = Some(row.archetype_name),
+                _ => {}
+            }
+        }
+
+        Ok((controller, opponent))
     }
 }

--- a/arenabuddy/data/src/db/metagame_repository.rs
+++ b/arenabuddy/data/src/db/metagame_repository.rs
@@ -25,6 +25,7 @@ pub trait MetagameRepository: Send + Sync + 'static {
     async fn upsert_match_archetype(&self, archetype: &MatchArchetype) -> Result<()>;
     async fn get_match_deck_cards(&self, match_id: &str) -> Result<Vec<String>>;
     async fn get_match_opponent_cards(&self, match_id: &str) -> Result<Vec<String>>;
+    async fn get_match_archetypes(&self, match_id: &str) -> Result<(Option<String>, Option<String>)>;
 }
 
 #[derive(Debug, Clone)]

--- a/arenabuddy/server/docker-compose.yml
+++ b/arenabuddy/server/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    ports:
+      - "127.0.0.1:5432:5432"
 
   tempo:
     image: grafana/tempo:2.6.1


### PR DESCRIPTION
This pull request adds archetype display functionality to match details and deck lists. The changes include:

- Added a new `--color-violet-200` CSS variable and corresponding `.text-violet-200` utility class
- Enhanced the `DeckList` component to accept an optional `archetype` parameter and display it below the deck title
- Updated the `MatchInfo` component to show archetype badges next to both controller and opponent player names when available
- Modified the match details page to pass archetype information to both the match info and deck list components
- Extended the backend service to fetch match archetypes from the database using a new `get_match_archetypes` method
- Added the `controller_archetype` and `opponent_archetype` fields to the `MatchDetails` struct
- Implemented the `get_match_archetypes` database method to query archetype information by match ID
- Added the method signature to the `MetagameRepository` trait
- Exposed the PostgreSQL port in the docker-compose configuration for local development access