### PR TITLE
Replace custom tracingx library with standard tracing ecosystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,12 +288,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "start",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tracing",
  "tracing-appender",
- "tracingx",
+ "tracing-subscriber",
  "urlencoding",
 ]
 
@@ -316,7 +316,8 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tracingx",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -328,7 +329,6 @@ dependencies = [
  "ctrlc",
  "derive_builder",
  "itertools 0.14.0",
- "multimap 0.1.0",
  "notify",
  "prost",
  "prost-types",
@@ -340,7 +340,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
- "tracingx",
+ "tracing",
  "uuid",
 ]
 
@@ -358,7 +358,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracingx",
 ]
 
 [[package]]
@@ -391,6 +390,9 @@ dependencies = [
  "chrono",
  "google-sheets4",
  "jsonwebtoken",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rand 0.10.0",
  "reqwest 0.13.2",
  "serde",
@@ -399,7 +401,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
- "tracingx",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
  "yup-oauth2",
 ]

--- a/arenabuddy/arenabuddy/Cargo.toml
+++ b/arenabuddy/arenabuddy/Cargo.toml
@@ -26,13 +26,13 @@ rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-start = { path = "../../lib/start" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing"] }
 tonic = { workspace = true }
-tracingx = { path = "../../lib/tracingx" }
-urlencoding = { workspace = true }
+tracing = { workspace = true }
 tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "registry"] }
+urlencoding = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rfd = { workspace = true, default_features = false, features = ["xdg-portal"] }

--- a/arenabuddy/arenabuddy/src/app/pages.rs
+++ b/arenabuddy/arenabuddy/src/app/pages.rs
@@ -11,7 +11,7 @@ use crate::{
 
 fn open_github() {
     if let Err(e) = open::that("https://github.com/gazure/monorepo") {
-        tracingx::error!("Failed to open URL: {}", e);
+        tracing::error!("Failed to open URL: {}", e);
     }
 }
 
@@ -132,16 +132,16 @@ fn Layout() -> Element {
                         let sync_auth = auth_state.clone();
                         bg.spawn(async move {
                             match crate::backend::sync::sync_matches(&sync_db, &sync_auth).await {
-                                Ok(n) => tracingx::info!("Post-login sync complete: {n} new matches"),
-                                Err(e) => tracingx::error!("Post-login sync failed: {e}"),
+                                Ok(n) => tracing::info!("Post-login sync complete: {n} new matches"),
+                                Err(e) => tracing::error!("Post-login sync failed: {e}"),
                             }
                         });
                     }
                     Ok(Err(e)) => {
-                        tracingx::error!("Login failed: {e}");
+                        tracing::error!("Login failed: {e}");
                     }
                     Err(_) => {
-                        tracingx::error!("Login task was dropped");
+                        tracing::error!("Login task was dropped");
                     }
                 }
                 login_loading.set(false);
@@ -167,13 +167,13 @@ fn Layout() -> Element {
                     });
                     match rx.await {
                         Ok(Ok(())) => {
-                            tracingx::info!("Logged out successfully");
+                            tracing::info!("Logged out successfully");
                         }
                         Ok(Err(e)) => {
-                            tracingx::error!("Logout failed: {e}");
+                            tracing::error!("Logout failed: {e}");
                         }
                         Err(_) => {
-                            tracingx::error!("Logout task was dropped");
+                            tracing::error!("Logout task was dropped");
                         }
                     }
                 }

--- a/arenabuddy/arenabuddy/src/backend/auth.rs
+++ b/arenabuddy/arenabuddy/src/backend/auth.rs
@@ -7,7 +7,7 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
-use tracingx::{error, info};
+use tracing::{error, info};
 
 /// Stored authentication state for the current session.
 #[derive(Debug, Clone)]

--- a/arenabuddy/arenabuddy/src/backend/grpc_writer.rs
+++ b/arenabuddy/arenabuddy/src/backend/grpc_writer.rs
@@ -7,7 +7,7 @@ use arenabuddy_core::{
 use arenabuddy_data::{MatchDB, MetagameRepository, metagame_models::MatchArchetype};
 use chrono::Utc;
 use tonic::transport::Channel;
-use tracingx::{error, info};
+use tracing::{error, info};
 
 use super::auth::{SharedAuthState, needs_refresh, refresh};
 

--- a/arenabuddy/arenabuddy/src/backend/ingest.rs
+++ b/arenabuddy/arenabuddy/src/backend/ingest.rs
@@ -11,7 +11,7 @@ use arenabuddy_core::{
 use arenabuddy_data::{DirectoryStorage, MatchDB};
 use tokio::sync::Mutex;
 use tonic::transport::Channel;
-use tracingx::{error, info};
+use tracing::{error, info};
 
 use super::{auth::SharedAuthState, grpc_writer::GrpcReplayWriter};
 
@@ -54,7 +54,7 @@ fn handle_ingestion_event(
     debug_client: Option<Arc<Mutex<DebugReporter>>>,
 ) -> PinnedFuture {
     Box::pin(async move {
-        tracingx::debug!("{event}");
+        tracing::debug!("{event}");
         if let IngestionEvent::ParseError(raw_json) = event {
             {
                 let mut collector = log_collector.lock().await;

--- a/arenabuddy/arenabuddy/src/backend/launch.rs
+++ b/arenabuddy/arenabuddy/src/backend/launch.rs
@@ -6,12 +6,14 @@ use dioxus::{
     LaunchBuilder,
     desktop::{Config, WindowBuilder},
 };
-use start::AppMeta;
+use tracing::{Level, error, info};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracingx::{
-    EnvFilter, Layer, Level, SubscriberExt, SubscriberInitExt, error,
+use tracing_subscriber::{
+    EnvFilter,
     fmt::{self, writer::MakeWriterExt},
-    info,
+    layer::{Layer, SubscriberExt},
+    registry,
+    util::SubscriberInitExt,
 };
 
 use crate::{
@@ -85,7 +87,7 @@ fn get_app_data_dir() -> Result<std::path::PathBuf> {
 }
 
 fn setup_logging(app_data_dir: &Path) -> Result<()> {
-    let registry = tracingx::registry();
+    let registry = registry();
     let log_dir = app_data_dir.join("logs");
     std::fs::create_dir_all(&log_dir).map_err(|_| Error::CorruptedAppData)?;
 
@@ -136,8 +138,8 @@ async fn create_app_service() -> Result<Service> {
     let data_dir = get_app_data_dir()?;
     setup_logging(&data_dir)?;
 
-    let app_meta = AppMeta::from_env().with_app_name("arenabuddy");
-    let root_span = tracingx::info_span!("app", app = %app_meta.app);
+    let app_name = std::env::var("APP_NAME").unwrap_or_else(|_| "arenabuddy".to_string());
+    let root_span = tracing::info_span!("app", app = %app_name);
     let _span = root_span.enter();
     let cards_db = CardsDatabase::default();
     let url = std::env::var("ARENABUDDY_DATABASE_URL").ok();

--- a/arenabuddy/arenabuddy/src/backend/service.rs
+++ b/arenabuddy/arenabuddy/src/backend/service.rs
@@ -15,7 +15,7 @@ use arenabuddy_core::{
 };
 use arenabuddy_data::{DirectoryStorage, MetagameRepository};
 use tokio::sync::Mutex;
-use tracingx::{error, info};
+use tracing::{error, info};
 
 use crate::Result;
 

--- a/arenabuddy/arenabuddy/src/backend/sync.rs
+++ b/arenabuddy/arenabuddy/src/backend/sync.rs
@@ -5,7 +5,7 @@ use arenabuddy_core::{
     services::match_service::{GetMatchDataRequest, ListMatchesRequest, match_service_client::MatchServiceClient},
 };
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
-use tracingx::{error, info};
+use tracing::{error, info};
 
 use super::auth::{SharedAuthState, needs_refresh, refresh};
 

--- a/arenabuddy/cli/Cargo.toml
+++ b/arenabuddy/cli/Cargo.toml
@@ -25,7 +25,8 @@ rustyline = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 thiserror = { workspace = true }
-tracingx = { path = "../../lib/tracingx" }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "registry"] }
 
 [[bin]]
 name = "arenabuddyctl"

--- a/arenabuddy/cli/src/commands/event_log.rs
+++ b/arenabuddy/cli/src/commands/event_log.rs
@@ -7,7 +7,7 @@ use arenabuddy_core::{
         replay::MatchReplay,
     },
 };
-use tracingx::info;
+use tracing::info;
 
 use crate::Result;
 

--- a/arenabuddy/cli/src/commands/metagame.rs
+++ b/arenabuddy/cli/src/commands/metagame.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Context;
 use arenabuddy_core::cards::CardsDatabase;
 use arenabuddy_data::{ArenabuddyRepository, MatchDB, MetagameRepository};
-use tracingx::info;
+use tracing::info;
 
 use super::definitions::MetagameCommands;
 use crate::Result;

--- a/arenabuddy/cli/src/commands/parse.rs
+++ b/arenabuddy/cli/src/commands/parse.rs
@@ -5,7 +5,7 @@ use arenabuddy_core::{
     player_log::ingest::{IngestionConfig, LogIngestionService},
 };
 use arenabuddy_data::{ArenabuddyRepository, DirectoryStorage, MatchDB};
-use tracingx::info;
+use tracing::info;
 
 use crate::Result;
 

--- a/arenabuddy/cli/src/commands/scrape.rs
+++ b/arenabuddy/cli/src/commands/scrape.rs
@@ -6,7 +6,7 @@ use std::{
 
 use arenabuddy_core::models::{Card, CardCollection};
 use reqwest::StatusCode;
-use tracingx::{debug, info};
+use tracing::{debug, info};
 
 use crate::{Error, Result, errors::ParseError};
 

--- a/arenabuddy/cli/src/commands/scrape_mtga.rs
+++ b/arenabuddy/cli/src/commands/scrape_mtga.rs
@@ -8,7 +8,7 @@ use std::{
 use arenabuddy_core::models::{Card, CardCollection};
 use reqwest::StatusCode;
 use rusqlite::Connection;
-use tracingx::{debug, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{Error, Result};
 

--- a/arenabuddy/cli/src/lib.rs
+++ b/arenabuddy/cli/src/lib.rs
@@ -19,7 +19,13 @@ struct Cli {
 
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
-    tracingx::init_dev();
+    tracing_subscriber::fmt()
+        .pretty()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     match &cli.command {
         Commands::Parse {

--- a/arenabuddy/core/Cargo.toml
+++ b/arenabuddy/core/Cargo.toml
@@ -24,7 +24,6 @@ chrono = { workspace = true, features = ["serde"] }
 ctrlc = { workspace = true }
 derive_builder = { workspace = true }
 itertools = { workspace = true }
-multimap = { path = "../../lib/multimap" }
 notify = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
@@ -35,7 +34,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracingx = { path = "../../lib/tracingx" }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 

--- a/arenabuddy/core/src/cards.rs
+++ b/arenabuddy/core/src/cards.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, fmt::Display, fs::File, io::Read, path::Path, sync::Arc};
 
 use prost::Message;
-use tracingx::debug;
+use tracing::debug;
 
 use crate::models::{Card, CardCollection};
 

--- a/arenabuddy/core/src/lib.rs
+++ b/arenabuddy/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod display;
 pub mod errors;
 pub mod events;
 pub mod models;
+pub mod multimap;
 pub mod player_log;
 pub(crate) mod proto;
 pub mod services;

--- a/arenabuddy/core/src/multimap.rs
+++ b/arenabuddy/core/src/multimap.rs
@@ -1,0 +1,176 @@
+use std::collections::{BTreeMap, btree_map::Entry};
+
+pub struct MultiMap<K, V> {
+    inner: BTreeMap<K, Vec<V>>,
+}
+
+impl<K: Ord, V> Default for MultiMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: Ord, V> MultiMap<K, V> {
+    pub fn new() -> Self {
+        Self { inner: BTreeMap::new() }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        self.inner.entry(key).or_default().push(value);
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.get_all(key)?.first()
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.get_all_mut(key)?.first_mut()
+    }
+
+    pub fn get_all(&self, key: &K) -> Option<&[V]> {
+        self.inner.get(key).map(std::convert::AsRef::as_ref)
+    }
+
+    pub fn get_all_mut(&mut self, key: &K) -> Option<&mut Vec<V>> {
+        self.inner.get_mut(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    pub fn remove_all(&mut self, key: &K) -> Option<Vec<V>> {
+        self.inner.remove(key)
+    }
+
+    pub fn pop(&mut self, key: &K) -> Option<V> {
+        let values = self.inner.get_mut(key)?;
+        let popped = values.pop();
+        if values.is_empty() {
+            self.inner.remove(key);
+        }
+        popped
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.inner.keys()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.inner.values().flat_map(|v| v.iter())
+    }
+
+    pub fn vec_values(&self) -> impl Iterator<Item = &Vec<V>> {
+        self.inner.values()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.inner.iter().flat_map(|(k, v)| v.iter().map(move |v| (k, v)))
+    }
+
+    pub fn vec_iter(&self) -> impl Iterator<Item = (&K, &Vec<V>)> {
+        self.inner.iter()
+    }
+
+    pub fn vec_iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut Vec<V>)> {
+        self.inner.iter_mut()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.inner
+            .iter_mut()
+            .flat_map(|(k, v)| v.iter_mut().map(move |v| (k, v)))
+    }
+
+    pub fn entry(&mut self, key: K) -> Entry<'_, K, Vec<V>> {
+        self.inner.entry(key)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let multimap: MultiMap<String, i32> = MultiMap::new();
+        assert_eq!(multimap.len(), 0);
+        assert_eq!(multimap.get(&"key".to_string()), None);
+    }
+
+    #[test]
+    fn test_insert_single_value() {
+        let mut multimap = MultiMap::new();
+        multimap.insert("key1", 10);
+
+        assert_eq!(multimap.get(&"key1"), Some(&10));
+        assert_eq!(multimap.len(), 1);
+    }
+
+    #[test]
+    fn test_insert_multiple_values_same_key() {
+        let mut multimap = MultiMap::new();
+        multimap.insert("key1", 10);
+        multimap.insert("key1", 20);
+        multimap.insert("key1", 30);
+
+        assert_eq!(multimap.get(&"key1"), Some(&10));
+        assert_eq!(multimap.get_all(&"key1"), Some(&[10, 20, 30][..]));
+        assert_eq!(multimap.len(), 1);
+    }
+
+    #[test]
+    fn test_get_all() {
+        let mut multimap = MultiMap::new();
+        multimap.insert("key1", 1);
+        multimap.insert("key1", 2);
+        multimap.insert("key1", 3);
+        multimap.insert("key2", 4);
+
+        assert_eq!(multimap.get_all(&"key1"), Some(&[1, 2, 3][..]));
+        assert_eq!(multimap.get_all(&"key2"), Some(&[4][..]));
+        assert_eq!(multimap.get_all(&"key3"), None);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut multimap = MultiMap::new();
+        multimap.insert("key1", 1);
+        multimap.insert("key1", 2);
+        multimap.insert("key2", 3);
+
+        multimap.clear();
+        assert_eq!(multimap.len(), 0);
+        assert_eq!(multimap.get(&"key1"), None);
+    }
+
+    #[test]
+    fn test_entry() {
+        let mut multimap = MultiMap::new();
+        multimap.entry("key1").or_default().push(10);
+        assert_eq!(multimap.get_all(&"key1"), Some(&[10][..]));
+
+        multimap.entry("key1").or_default().push(20);
+        assert_eq!(multimap.get_all(&"key1"), Some(&[10, 20][..]));
+    }
+
+    #[test]
+    fn test_vec_values() {
+        let mut multimap = MultiMap::new();
+        multimap.insert("key1", 1);
+        multimap.insert("key1", 2);
+        multimap.insert("key2", 3);
+
+        let vec_values: Vec<_> = multimap.vec_values().collect();
+        assert_eq!(vec_values[0], &vec![1, 2]);
+        assert_eq!(vec_values[1], &vec![3]);
+    }
+}

--- a/arenabuddy/core/src/player_log/draft.rs
+++ b/arenabuddy/core/src/player_log/draft.rs
@@ -1,11 +1,11 @@
 #![expect(clippy::similar_names)]
-use multimap::MultiMap;
 use uuid::Uuid;
 
 use crate::{
     Error, Result,
     events::business::{BusinessEvent, DraftPackInfoEvent},
     models::{ArenaId, Draft, DraftPack, Format, MTGADraft},
+    multimap::MultiMap,
     player_log::ingest::DraftWriter,
 };
 
@@ -47,7 +47,7 @@ impl DraftBuilder {
     /// errors if there is an issue writing the draft results to storage
     pub async fn process_event(&mut self, event: &BusinessEvent) -> Result<()> {
         if let BusinessEvent::Draft(e) = event {
-            tracingx::debug!("Processing draft event: {e:?}");
+            tracing::debug!("Processing draft event: {e:?}");
             let format = parse_event_id(&e.event_id).0;
             self.process_pack_event(e);
 
@@ -69,7 +69,7 @@ impl DraftBuilder {
             pick_number: draft_pack_info_event.pick_number,
         };
 
-        tracingx::info!("Pack #{}, Pick #{}", pack.pack_number, pack.pick_number);
+        tracing::info!("Pack #{}, Pick #{}", pack.pack_number, pack.pick_number);
         let last_pack = pack.pack_number;
         let last_pick = pack.pick_number;
         let pp = PackPick(last_pack, last_pick);
@@ -90,7 +90,7 @@ impl DraftBuilder {
                             pack.pack_number,
                             pack.pick_number,
                             selection_num.try_into().unwrap_or_else(|e| {
-                                tracingx::warn!(
+                                tracing::warn!(
                                     "Could not identify selection number for PackPick: {pack:?}. error: {e}"
                                 );
                                 0u8

--- a/arenabuddy/core/src/player_log/event_log.rs
+++ b/arenabuddy/core/src/player_log/event_log.rs
@@ -2,7 +2,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use tracingx::debug;
+use tracing::debug;
 
 use crate::{
     cards::CardsDatabase,

--- a/arenabuddy/core/src/player_log/ingest.rs
+++ b/arenabuddy/core/src/player_log/ingest.rs
@@ -9,7 +9,7 @@ use tokio::{
     sync::mpsc::{self},
     time::interval,
 };
-use tracingx::{debug, error, info};
+use tracing::{debug, error, info};
 
 use crate::{
     Error, Result,

--- a/arenabuddy/core/src/player_log/processor.rs
+++ b/arenabuddy/core/src/player_log/processor.rs
@@ -4,7 +4,7 @@ use tokio::{
     fs::File,
     io::{AsyncBufReadExt, BufReader},
 };
-use tracingx::{debug, error};
+use tracing::{debug, error};
 
 use crate::{
     Result,

--- a/arenabuddy/core/src/player_log/replay.rs
+++ b/arenabuddy/core/src/player_log/replay.rs
@@ -5,7 +5,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
-use tracingx::{debug, info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     Error, Result,

--- a/arenabuddy/data/Cargo.toml
+++ b/arenabuddy/data/Cargo.toml
@@ -26,7 +26,6 @@ sqlx = { workspace = true, features = [
 tokio = { workspace = true, features = ["full"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracingx = { path = "../../lib/tracingx" }
 
 [lints]
 workspace = true

--- a/arenabuddy/data/src/db/postgres.rs
+++ b/arenabuddy/data/src/db/postgres.rs
@@ -17,7 +17,7 @@ use arenabuddy_core::{
 use chrono::{DateTime, NaiveDateTime, Utc};
 use postgresql_embedded::PostgreSQL;
 use sqlx::{FromRow, PgPool, Postgres, Transaction, types::Uuid};
-use tracingx::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 #[derive(FromRow)]
 struct MatchRow {

--- a/arenabuddy/data/src/storage/directory.rs
+++ b/arenabuddy/data/src/storage/directory.rs
@@ -6,7 +6,7 @@ use arenabuddy_core::{
 };
 use async_trait::async_trait;
 use tokio::fs::File;
-use tracingx::info;
+use tracing::info;
 
 pub struct DirectoryStorage {
     path: PathBuf,

--- a/arenabuddy/server/Cargo.toml
+++ b/arenabuddy/server/Cargo.toml
@@ -30,13 +30,22 @@ sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tracing = { workspace = true }
-tracingx = { path = "../../lib/tracingx" }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "registry"] }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
 uuid = { workspace = true }
 yup-oauth2 = { workspace = true }
 
 [features]
 default = []
-otel = ["tracingx/otel"]
+otel = [
+    "dep:tracing-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+]
 
 [lints]
 workspace = true

--- a/arenabuddy/server/src/auth.rs
+++ b/arenabuddy/server/src/auth.rs
@@ -10,7 +10,7 @@ use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode}
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tonic::{Request, Response, Status};
-use tracingx::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument};
 use uuid::Uuid;
 
 const ACCESS_TOKEN_LIFETIME_MINUTES: i64 = 15;

--- a/arenabuddy/server/src/debug_service.rs
+++ b/arenabuddy/server/src/debug_service.rs
@@ -3,7 +3,7 @@ use arenabuddy_core::services::debug_service::{
 };
 use arenabuddy_data::{DebugRepository, MatchDB};
 use tonic::{Request, Response, Status};
-use tracingx::{error, info, instrument};
+use tracing::{error, info, instrument};
 
 use crate::auth::UserId;
 

--- a/arenabuddy/server/src/lib.rs
+++ b/arenabuddy/server/src/lib.rs
@@ -9,7 +9,7 @@ use arenabuddy_core::{
 };
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
 use tonic::transport::Server;
-use tracingx::info;
+use tracing::info;
 
 use crate::{
     auth::{AuthConfig, AuthServiceImpl, auth_interceptor},
@@ -20,6 +20,8 @@ use crate::{
 pub mod auth;
 mod debug_service;
 mod match_service;
+#[cfg(feature = "otel")]
+mod otel;
 mod sheets_sync;
 
 /// Start the gRPC server with all services.
@@ -33,9 +35,20 @@ mod sheets_sync;
 /// `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, or `JWT_SECRET`.
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "otel")]
-    let otel_guard = tracingx::otel::init_compact_with_otel("arenabuddy-server");
+    let otel_guard = otel::init_compact_with_otel("arenabuddy-server");
     #[cfg(not(feature = "otel"))]
-    tracingx::init_compact();
+    {
+        use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+        let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+        let fmt_layer = fmt::layer()
+            .compact()
+            .with_target(true)
+            .with_level(true)
+            .with_thread_names(false)
+            .with_file(false)
+            .with_line_number(false);
+        Registry::default().with(env_filter).with(fmt_layer).init();
+    }
 
     #[cfg(feature = "otel")]
     {

--- a/arenabuddy/server/src/match_service.rs
+++ b/arenabuddy/server/src/match_service.rs
@@ -9,7 +9,7 @@ use arenabuddy_core::{
 };
 use arenabuddy_data::{ArenabuddyRepository, MatchDB};
 use tonic::{Request, Response, Status};
-use tracingx::{error, info, instrument};
+use tracing::{error, info, instrument};
 
 use crate::auth::UserId;
 

--- a/arenabuddy/server/src/otel.rs
+++ b/arenabuddy/server/src/otel.rs
@@ -1,0 +1,58 @@
+use opentelemetry::trace::TracerProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+fn build_provider(service_name: &str) -> SdkTracerProvider {
+    use opentelemetry::KeyValue;
+    use opentelemetry_sdk::Resource;
+
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .expect("failed to create OTLP span exporter");
+
+    SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(
+            Resource::builder()
+                .with_attributes([KeyValue::new("service.name", service_name.to_owned())])
+                .build(),
+        )
+        .build()
+}
+
+pub struct OtelGuard {
+    provider: SdkTracerProvider,
+}
+
+impl OtelGuard {
+    pub fn shutdown(self) {
+        if let Err(e) = self.provider.shutdown() {
+            eprintln!("OpenTelemetry shutdown error: {e}");
+        }
+    }
+}
+
+pub fn init_compact_with_otel(service_name: &str) -> OtelGuard {
+    let provider = build_provider(service_name);
+    let tracer = provider.tracer(service_name.to_owned());
+    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    Registry::default()
+        .with(env_filter)
+        .with(
+            fmt::layer()
+                .compact()
+                .with_target(true)
+                .with_level(true)
+                .with_file(false)
+                .with_line_number(false)
+                .with_thread_names(false),
+        )
+        .with(otel_layer)
+        .init();
+
+    OtelGuard { provider }
+}

--- a/arenabuddy/server/src/sheets_sync.rs
+++ b/arenabuddy/server/src/sheets_sync.rs
@@ -18,7 +18,7 @@ use google_sheets4::{
     },
 };
 use serde_json::json;
-use tracingx::{error, info};
+use tracing::{error, info};
 use uuid::Uuid;
 
 fn match_details_sheet_row(md: &MatchDetails) -> Vec<serde_json::Value> {


### PR DESCRIPTION
This pull request replaces the custom `tracingx` library with the standard `tracing` ecosystem crates. The changes include:

**Dependency Updates:**
- Removed `tracingx` and `start` custom library dependencies
- Added `tracing`, `tracing-subscriber`, `tracing-appender`, and `tracing-opentelemetry` as direct dependencies
- Removed unused `multimap` dependency from core crate

**Code Changes:**
- Updated all logging calls from `tracingx::` to `tracing::` macros
- Replaced custom logging initialization with standard `tracing-subscriber` setup
- Migrated OpenTelemetry integration to use `tracing-opentelemetry` layer
- Moved multimap implementation from external library into the core crate
- Updated CLI to use `tracing-subscriber::fmt()` for development logging
- Replaced custom app metadata handling with simple environment variable lookup

**OpenTelemetry Support:**
- Maintained optional OpenTelemetry feature with proper conditional compilation
- Created dedicated `otel` module in server for OpenTelemetry initialization
- Added proper shutdown handling for OpenTelemetry provider

The migration maintains all existing logging functionality while adopting the standard Rust tracing ecosystem, improving maintainability and reducing custom library dependencies.