### PR TITLE
[baseballref] Increase start_time VARCHAR size to 50

### DIFF
--- a/sports/baseballref/migrations/007_increase_start_time_varchar.sql
+++ b/sports/baseballref/migrations/007_increase_start_time_varchar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE games ALTER COLUMN start_time TYPE VARCHAR(50);

--- a/sports/baseballref/src/scraper/client.rs
+++ b/sports/baseballref/src/scraper/client.rs
@@ -17,7 +17,7 @@ const USER_AGENT: &str = "Mozilla/5.0 (compatible; BaseballScraper/1.0; educatio
 /// Base delay between requests (~2 requests/second)
 const BASE_DELAY: Duration = Duration::from_secs(3);
 /// Maximum delay after repeated backoffs
-const MAX_DELAY: Duration = Duration::from_secs(300);
+const MAX_DELAY: Duration = Duration::from_mins(5);
 /// Multiplier applied to delay on rate-limit or server errors
 const BACKOFF_MULTIPLIER: f64 = 4.0;
 /// Maximum retries per request before giving up


### PR DESCRIPTION
Increases the `start_time` column size in the `games` table from its current VARCHAR length to VARCHAR(50) to accommodate longer time string values.