### PR TITLE
Add touch/mobile support with HUD buttons and getrandom wasm backend

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4918,11 +4918,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6385,6 +6387,7 @@ name = "life"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "getrandom 0.4.2",
  "rand 0.10.1",
 ]
 

--- a/life/Cargo.toml
+++ b/life/Cargo.toml
@@ -27,5 +27,10 @@ rand.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { workspace = true, features = ["file_watcher"] }
 
+# getrandom needs an explicit backend on browser wasm; also requires
+# `--cfg getrandom_backend="wasm_js"` (set in .cargo/config.toml)
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }
+
 [lints]
 workspace = true

--- a/life/src/game/components.rs
+++ b/life/src/game/components.rs
@@ -98,6 +98,18 @@ pub fn world_to_grid(world_x: f32, world_y: f32) -> ((i32, i32), (usize, usize))
 //     pub y: usize,
 // }
 
+/// Root node of the in-game touch HUD (play/pause, randomize, clear)
+#[derive(Component)]
+pub struct GameHud;
+
+/// Action performed by a HUD button when tapped/clicked
+#[derive(Component, Clone, Copy)]
+pub enum HudAction {
+    TogglePause,
+    Randomize,
+    Clear,
+}
+
 #[derive(Component)]
 pub struct Chunk {
     pub x: i32,

--- a/life/src/game/mod.rs
+++ b/life/src/game/mod.rs
@@ -22,6 +22,8 @@ impl Plugin for GamePlugin {
                     systems::manage_chunks,
                     systems::process_chunk_operations,
                     systems::handle_mouse_input,
+                    systems::handle_touch_input,
+                    systems::handle_hud_buttons,
                     systems::update_grid,
                 )
                     .run_if(in_state(GameState::Playing)),

--- a/life/src/game/systems.rs
+++ b/life/src/game/systems.rs
@@ -4,9 +4,10 @@ use bevy::prelude::*;
 
 use super::{
     components::{
-        ActiveGrid, CELL_SIZE, CHUNK_LOAD_RADIUS, Chunk, ChunkCell, DEAD_COLOR, GRID_HEIGHT, GRID_WIDTH, Grid,
-        activation_count_color, binary_color, chunk_to_world, fire_color, generation_based_color, monochrome_color,
-        neighbor_count_color, neon_color, ocean_color, pastel_rainbow_color, world_to_chunk, world_to_grid,
+        ActiveGrid, CELL_SIZE, CHUNK_LOAD_RADIUS, Chunk, ChunkCell, DEAD_COLOR, GRID_HEIGHT, GRID_WIDTH, GameHud, Grid,
+        HudAction, activation_count_color, binary_color, chunk_to_world, fire_color, generation_based_color,
+        monochrome_color, neighbor_count_color, neon_color, ocean_color, pastel_rainbow_color, world_to_chunk,
+        world_to_grid,
     },
     resources::{ChunkManager, ChunkOperation, ColorPattern, SimulationState},
 };
@@ -91,6 +92,53 @@ fn hide_chunk(commands: &mut Commands, chunk_entity: Entity) {
     commands.entity(chunk_entity).insert(Visibility::Hidden);
 }
 
+/// Spawns the touch-friendly HUD: play/pause, randomize, and clear buttons.
+/// Keyboard shortcuts still work; this exists so the game is playable on
+/// touch-only devices (mobile web).
+fn spawn_hud(commands: &mut Commands) {
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(16.0),
+                left: Val::Px(0.0),
+                right: Val::Px(0.0),
+                justify_content: JustifyContent::Center,
+                column_gap: Val::Px(12.0),
+                ..default()
+            },
+            GameHud,
+        ))
+        .with_children(|parent| {
+            for (label, action) in [
+                ("Play/Pause", HudAction::TogglePause),
+                ("Random", HudAction::Randomize),
+                ("Clear", HudAction::Clear),
+            ] {
+                parent
+                    .spawn((
+                        Button,
+                        Node {
+                            padding: UiRect::axes(Val::Px(18.0), Val::Px(12.0)),
+                            ..default()
+                        },
+                        BackgroundColor(Color::srgba(0.25, 0.25, 0.35, 0.85)),
+                        action,
+                    ))
+                    .with_children(|button| {
+                        button.spawn((
+                            Text::new(label),
+                            TextFont {
+                                font_size: 18.0,
+                                ..default()
+                            },
+                            TextColor(Color::WHITE),
+                        ));
+                    });
+            }
+        });
+}
+
 pub fn setup(mut commands: Commands) {
     let grid = Grid::default_randomized();
 
@@ -104,9 +152,45 @@ pub fn setup(mut commands: Commands) {
         InheritedVisibility::default(),
     ));
 
+    spawn_hud(&mut commands);
+
     // Initialize chunk manager
     commands.insert_resource(ChunkManager::default());
     commands.insert_resource(SimulationState::default());
+}
+
+#[expect(clippy::type_complexity)]
+pub fn handle_hud_buttons(
+    interaction_query: Query<(&Interaction, &HudAction), (Changed<Interaction>, With<Button>)>,
+    mut grid_query: Query<&mut Grid, With<ActiveGrid>>,
+    mut state: ResMut<SimulationState>,
+) {
+    for (interaction, action) in &interaction_query {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+
+        match action {
+            HudAction::TogglePause => {
+                state.paused = !state.paused;
+                info!("Simulation {}", if state.paused { "paused" } else { "running" });
+            }
+            HudAction::Randomize => {
+                if let Ok(mut grid) = grid_query.single_mut() {
+                    grid.randomize();
+                    state.generation = 0;
+                    info!("Grid randomized");
+                }
+            }
+            HudAction::Clear => {
+                if let Ok(mut grid) = grid_query.single_mut() {
+                    grid.clear();
+                    state.generation = 0;
+                    info!("Grid cleared");
+                }
+            }
+        }
+    }
 }
 
 pub fn update_grid(
@@ -307,6 +391,7 @@ pub fn handle_mouse_input(
     mouse_button: Res<ButtonInput<MouseButton>>,
     windows: Query<&Window>,
     camera_query: Query<(&Camera, &GlobalTransform)>,
+    button_query: Query<&Interaction, With<Button>>,
     mut grid_query: Query<&mut Grid, With<ActiveGrid>>,
     state: Res<SimulationState>,
 ) {
@@ -317,6 +402,11 @@ pub fn handle_mouse_input(
     if clicked {
         debug!("Mouse button clicked: {}", clicked);
     } else {
+        return;
+    }
+
+    // Don't draw cells through HUD buttons
+    if button_query.iter().any(|i| *i != Interaction::None) {
         return;
     }
 
@@ -352,6 +442,98 @@ pub fn handle_mouse_input(
     if !grid.get(grid_x, grid_y) {
         grid.set(grid_x, grid_y, true, state.generation);
         debug!("Cell activated at grid ({}, {})", grid_x, grid_y);
+    }
+}
+
+/// Finger movement (in logical pixels) below which a touch counts as a tap
+/// rather than a pan.
+const TAP_MOVE_THRESHOLD: f32 = 12.0;
+
+/// Per-gesture state for touch input, reset when all fingers lift.
+#[derive(Default)]
+pub struct TouchGesture {
+    /// Total distance the primary finger has moved; distinguishes tap from pan
+    moved: f32,
+    /// Distance between two fingers on the previous frame (pinch zoom)
+    last_pinch_distance: Option<f32>,
+    /// The gesture began on a HUD button, so it never draws or pans
+    started_on_ui: bool,
+}
+
+/// Touch controls for mobile/web: one-finger drag pans, pinch zooms, and a
+/// short tap draws a cell (mirroring a mouse click).
+pub fn handle_touch_input(
+    touches: Res<Touches>,
+    button_query: Query<&Interaction, With<Button>>,
+    mut camera_query: Query<(&Camera, &GlobalTransform, &mut Transform)>,
+    mut grid_query: Query<&mut Grid, With<ActiveGrid>>,
+    state: Res<SimulationState>,
+    mut gesture: Local<TouchGesture>,
+) {
+    let Ok((camera, camera_global, mut camera_transform)) = camera_query.single_mut() else {
+        return;
+    };
+
+    // Bevy's UI focus system has already run this frame, so a touch that
+    // landed on a HUD button shows up as a pressed interaction here.
+    if touches.any_just_pressed() && button_query.iter().any(|i| *i != Interaction::None) {
+        gesture.started_on_ui = true;
+    }
+
+    let active: Vec<_> = touches.iter().collect();
+
+    match active.len() {
+        1 if !gesture.started_on_ui => {
+            let touch = active[0];
+            gesture.moved += touch.delta().length();
+            gesture.last_pinch_distance = None;
+
+            // Once past the tap threshold, drag pans the camera (screen y is
+            // inverted relative to world y)
+            if gesture.moved > TAP_MOVE_THRESHOLD {
+                let scale = camera_transform.scale.x;
+                camera_transform.translation.x -= touch.delta().x * scale;
+                camera_transform.translation.y += touch.delta().y * scale;
+            }
+        }
+        2.. => {
+            // A pinch never ends in a tap
+            gesture.moved = f32::MAX;
+
+            let distance = active[0].position().distance(active[1].position());
+            if let Some(last_distance) = gesture.last_pinch_distance
+                && distance > 1.0
+            {
+                // Fingers moving apart shrinks camera scale = zooms in
+                let new_scale = (camera_transform.scale.x * (last_distance / distance)).clamp(0.5, 5.0);
+                camera_transform.scale = Vec3::splat(new_scale);
+            }
+            gesture.last_pinch_distance = Some(distance);
+
+            // Two-finger drag also pans, following the midpoint
+            let scale = camera_transform.scale.x;
+            let delta = (active[0].delta() + active[1].delta()) / 2.0;
+            camera_transform.translation.x -= delta.x * scale;
+            camera_transform.translation.y += delta.y * scale;
+        }
+        _ => gesture.last_pinch_distance = None,
+    }
+
+    if active.is_empty() {
+        for touch in touches.iter_just_released() {
+            if gesture.moved <= TAP_MOVE_THRESHOLD
+                && !gesture.started_on_ui
+                && let Ok(world_pos) = camera.viewport_to_world_2d(camera_global, touch.position())
+                && let Ok(mut grid) = grid_query.single_mut()
+            {
+                let (_, (grid_x, grid_y)) = world_to_grid(world_pos.x, world_pos.y);
+                if !grid.get(grid_x, grid_y) {
+                    grid.set(grid_x, grid_y, true, state.generation);
+                    debug!("Cell activated by tap at grid ({}, {})", grid_x, grid_y);
+                }
+            }
+        }
+        *gesture = TouchGesture::default();
     }
 }
 
@@ -514,11 +696,17 @@ pub fn cleanup_game(
     mut commands: Commands,
     grid_query: Query<Entity, With<ActiveGrid>>,
     chunk_query: Query<Entity, With<Chunk>>,
+    hud_query: Query<Entity, With<GameHud>>,
 ) {
     info!("Cleaning up game");
 
     // Despawn all chunks (cascades to cells)
     for entity in &chunk_query {
+        commands.entity(entity).despawn();
+    }
+
+    // Despawn HUD (cascades to buttons)
+    for entity in &hud_query {
         commands.entity(entity).despawn();
     }
 

--- a/life/src/menu/systems.rs
+++ b/life/src/menu/systems.rs
@@ -33,7 +33,7 @@ pub fn setup_menu(mut commands: Commands) {
             ));
 
             parent.spawn((
-                Text::new("Press SPACE to Start"),
+                Text::new("Press SPACE or Tap to Start"),
                 TextFont {
                     font_size: 30.0,
                     ..default()
@@ -64,8 +64,15 @@ pub fn setup_menu(mut commands: Commands) {
         });
 }
 
-pub fn menu_action(keyboard: Res<ButtonInput<KeyCode>>, mut next_state: ResMut<NextState<GameState>>) {
-    if keyboard.just_pressed(KeyCode::Space) {
+pub fn menu_action(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    touches: Res<Touches>,
+    mouse: Res<ButtonInput<MouseButton>>,
+    mut next_state: ResMut<NextState<GameState>>,
+) {
+    // Trigger on release (not press) so the same touch/click doesn't also
+    // draw a cell once the Playing state's input systems take over
+    if keyboard.just_pressed(KeyCode::Space) || touches.any_just_released() || mouse.just_released(MouseButton::Left) {
         next_state.set(GameState::Playing);
         info!("Starting game");
     }


### PR DESCRIPTION
This PR adds touch and mobile web support to the Game of Life simulation.

A touch-friendly HUD is spawned at the bottom of the screen containing Play/Pause, Randomize, and Clear buttons. These mirror the existing keyboard shortcuts and are handled by a new `handle_hud_buttons` system. The HUD is properly despawned during game cleanup.

Touch input is handled by a new `handle_touch_input` system with the following gesture support:
- **Single-finger drag** pans the camera
- **Pinch** zooms the camera in or out
- **Short tap** (below a 12px movement threshold) draws a cell, mirroring a mouse click
- Gestures that begin on a HUD button are ignored for drawing and panning

Mouse input is also guarded so that clicking HUD buttons does not draw cells through them. The menu now accepts a tap or mouse click (on release) in addition to the spacebar to start the game, and the prompt text is updated to reflect this.

To support `getrandom` in the browser WebAssembly target, the `wasm_js` backend is explicitly enabled via a target-specific dependency and a `rustflags` entry in `.cargo/config.toml`.