### PR TITLE
[baseballref] Fix team assignment in batting/pitching/PBP parsers and add rescrape command

### DIFF
--- a/sports/baseballref/scripts/repair_team_assignment.sql
+++ b/sports/baseballref/scripts/repair_team_assignment.sql
@@ -1,0 +1,174 @@
+-- Repair batting_lines.team_id / pitching_lines.team_id for games scraped
+-- before the table-order fix (parsers assigned teams by matching the team
+-- code against table ids like "LosAngelesDodgersbatting", which usually
+-- fails and fell back to the home code, or to the away code for Dodgers
+-- tables).
+--
+-- Method: within a game, rows were inserted in parse order (ids ascend), the
+-- away table first then the home table, and batting_order/pitch_order restart
+-- at 1 per table. Splitting each game's rows at the order-reset yields the two
+-- table blocks. Each block's true team comes from a majority vote of its
+-- members' play_by_play batting teams (or fielding teams, for pitchers) —
+-- which also handles relocated "home" games where the home table renders
+-- first. Games whose blocks can't be resolved are listed for re-scraping.
+--
+-- Run: psql "$SPORTS_DATABASE_URL" -f repair_team_assignment.sql
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Batting lines: block membership via batting_order resets
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE bat_blocks AS
+SELECT id,
+       game_id,
+       team_id,
+       player_id,
+       sum(is_reset) OVER (PARTITION BY game_id ORDER BY id) AS block
+FROM (
+    SELECT bl.id, bl.game_id, bl.team_id, bl.player_id,
+           CASE WHEN bl.batting_order <= lag(bl.batting_order) OVER (PARTITION BY bl.game_id ORDER BY bl.id)
+                THEN 1 ELSE 0 END AS is_reset
+    FROM batting_lines bl
+) x;
+
+-- Batter -> team from play-by-play (mode over events, ties broken arbitrarily)
+CREATE TEMP TABLE pbp_batter_team AS
+SELECT DISTINCT ON (game_id, batter_id) game_id, batter_id, batting_team_id AS team_id
+FROM (
+    SELECT game_id, batter_id, batting_team_id, count(*) AS n
+    FROM play_by_play
+    GROUP BY 1, 2, 3
+) t
+ORDER BY game_id, batter_id, n DESC;
+
+-- Majority vote per block
+CREATE TEMP TABLE bat_block_team AS
+SELECT game_id, block, team_id AS voted_team_id, votes, total_votes
+FROM (
+    SELECT b.game_id, b.block, p.team_id,
+           count(*) AS votes,
+           sum(count(*)) OVER (PARTITION BY b.game_id, b.block) AS total_votes,
+           row_number() OVER (PARTITION BY b.game_id, b.block ORDER BY count(*) DESC) AS rk
+    FROM bat_blocks b
+    JOIN pbp_batter_team p ON p.game_id = b.game_id AND p.batter_id = b.player_id
+    GROUP BY 1, 2, 3
+) v
+WHERE rk = 1;
+
+-- Resolvable games: exactly 2 blocks, each voted unanimously-enough (>= 80%),
+-- blocks voted for the two distinct teams of the game
+CREATE TEMP TABLE bat_resolved AS
+SELECT g.id AS game_id,
+       min(bt.voted_team_id) FILTER (WHERE bt.block = 0) AS block0_team,
+       min(bt.voted_team_id) FILTER (WHERE bt.block = 1) AS block1_team
+FROM games g
+JOIN bat_block_team bt ON bt.game_id = g.id
+WHERE bt.votes::float8 / bt.total_votes::float8 >= 0.8
+GROUP BY g.id
+HAVING count(DISTINCT bt.block) = 2
+   AND count(*) = 2
+   AND min(bt.voted_team_id) FILTER (WHERE bt.block = 0)
+       <> min(bt.voted_team_id) FILTER (WHERE bt.block = 1)
+   AND min(bt.voted_team_id) FILTER (WHERE bt.block = 0) IN (g.away_team_id, g.home_team_id)
+   AND min(bt.voted_team_id) FILTER (WHERE bt.block = 1) IN (g.away_team_id, g.home_team_id);
+
+-- Games with any misassigned row, restricted to resolvable ones
+CREATE TEMP TABLE bat_repairs AS
+SELECT bb.id, bb.game_id, CASE WHEN bb.block = 0 THEN r.block0_team ELSE r.block1_team END AS new_team_id
+FROM bat_blocks bb
+JOIN bat_resolved r ON r.game_id = bb.game_id
+WHERE bb.team_id <> CASE WHEN bb.block = 0 THEN r.block0_team ELSE r.block1_team END;
+
+SELECT count(*) AS batting_rows_to_fix, count(DISTINCT game_id) AS batting_games_to_fix FROM bat_repairs;
+
+UPDATE batting_lines bl
+SET team_id = br.new_team_id
+FROM bat_repairs br
+WHERE bl.id = br.id;
+
+-- ---------------------------------------------------------------------------
+-- Pitching lines: same approach via pitch_order resets; a pitcher's team is
+-- the fielding side of their play-by-play events
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE pit_blocks AS
+SELECT id,
+       game_id,
+       team_id,
+       player_id,
+       sum(is_reset) OVER (PARTITION BY game_id ORDER BY id) AS block
+FROM (
+    -- Orders strictly increase within a table, so an equal-or-lower order
+    -- marks the second table (covers one-pitcher complete games: 1, 1).
+    SELECT pl.id, pl.game_id, pl.team_id, pl.player_id,
+           CASE WHEN pl.pitch_order <= lag(pl.pitch_order) OVER (PARTITION BY pl.game_id ORDER BY pl.id)
+                THEN 1 ELSE 0 END AS is_reset
+    FROM pitching_lines pl
+) x;
+
+CREATE TEMP TABLE pbp_pitcher_team AS
+SELECT DISTINCT ON (p.game_id, p.pitcher_id) p.game_id, p.pitcher_id,
+       CASE WHEN p.batting_team_id = g.home_team_id THEN g.away_team_id ELSE g.home_team_id END AS team_id
+FROM (
+    SELECT game_id, pitcher_id, batting_team_id, count(*) AS n
+    FROM play_by_play
+    GROUP BY 1, 2, 3
+) p
+JOIN games g ON g.id = p.game_id
+ORDER BY p.game_id, p.pitcher_id, p.n DESC;
+
+CREATE TEMP TABLE pit_block_team AS
+SELECT game_id, block, team_id AS voted_team_id, votes, total_votes
+FROM (
+    SELECT b.game_id, b.block, p.team_id,
+           count(*) AS votes,
+           sum(count(*)) OVER (PARTITION BY b.game_id, b.block) AS total_votes,
+           row_number() OVER (PARTITION BY b.game_id, b.block ORDER BY count(*) DESC) AS rk
+    FROM pit_blocks b
+    JOIN pbp_pitcher_team p ON p.game_id = b.game_id AND p.pitcher_id = b.player_id
+    GROUP BY 1, 2, 3
+) v
+WHERE rk = 1;
+
+CREATE TEMP TABLE pit_resolved AS
+SELECT g.id AS game_id,
+       min(bt.voted_team_id) FILTER (WHERE bt.block = 0) AS block0_team,
+       min(bt.voted_team_id) FILTER (WHERE bt.block = 1) AS block1_team
+FROM games g
+JOIN pit_block_team bt ON bt.game_id = g.id
+WHERE bt.votes::float8 / bt.total_votes::float8 >= 0.8
+GROUP BY g.id
+HAVING count(DISTINCT bt.block) = 2
+   AND count(*) = 2
+   AND min(bt.voted_team_id) FILTER (WHERE bt.block = 0)
+       <> min(bt.voted_team_id) FILTER (WHERE bt.block = 1)
+   AND min(bt.voted_team_id) FILTER (WHERE bt.block = 0) IN (g.away_team_id, g.home_team_id)
+   AND min(bt.voted_team_id) FILTER (WHERE bt.block = 1) IN (g.away_team_id, g.home_team_id);
+
+CREATE TEMP TABLE pit_repairs AS
+SELECT pb.id, pb.game_id, CASE WHEN pb.block = 0 THEN r.block0_team ELSE r.block1_team END AS new_team_id
+FROM pit_blocks pb
+JOIN pit_resolved r ON r.game_id = pb.game_id
+WHERE pb.team_id <> CASE WHEN pb.block = 0 THEN r.block0_team ELSE r.block1_team END;
+
+SELECT count(*) AS pitching_rows_to_fix, count(DISTINCT game_id) AS pitching_games_to_fix FROM pit_repairs;
+
+UPDATE pitching_lines pl
+SET team_id = pr.new_team_id
+FROM pit_repairs pr
+WHERE pl.id = pr.id;
+
+-- ---------------------------------------------------------------------------
+-- Unresolvable games (need re-scrape): still misassigned after repair
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE still_bad AS
+SELECT g.id, g.bbref_game_id
+FROM games g
+WHERE (SELECT count(*) FILTER (WHERE bl.team_id = g.away_team_id) FROM batting_lines bl WHERE bl.game_id = g.id) < 5
+   OR (SELECT count(*) FILTER (WHERE bl.team_id = g.home_team_id) FROM batting_lines bl WHERE bl.game_id = g.id) < 5
+   OR (SELECT count(*) FILTER (WHERE pl.team_id = g.away_team_id) FROM pitching_lines pl WHERE pl.game_id = g.id) < 1
+   OR (SELECT count(*) FILTER (WHERE pl.team_id = g.home_team_id) FROM pitching_lines pl WHERE pl.game_id = g.id) < 1;
+
+SELECT count(*) AS games_still_bad FROM still_bad;
+
+COMMIT;

--- a/sports/baseballref/src/cli.rs
+++ b/sports/baseballref/src/cli.rs
@@ -172,6 +172,24 @@ pub enum BaseballCommands {
         skip_future: bool,
     },
 
+    /// Delete and re-scrape specific games listed by bbref game id
+    RescrapeGames {
+        /// File with one bbref game id per line (e.g. "BOS202305010")
+        ids_file: PathBuf,
+
+        /// Database URL (or set `SPORTS_DATABASE_URL` env var)
+        #[arg(short, long, env = "SPORTS_DATABASE_URL")]
+        database_url: String,
+
+        /// Directory to save downloaded HTML files
+        #[arg(short, long)]
+        output_dir: Option<PathBuf>,
+
+        /// Maximum number of games to rescrape (for testing)
+        #[arg(short = 'n', long)]
+        limit: Option<usize>,
+    },
+
     /// Retry importing all scraped games from a directory
     RetryImports {
         /// Directory containing .shtml files
@@ -713,6 +731,76 @@ pub async fn handle_command(command: BaseballCommands) -> anyhow::Result<()> {
             if total_failed > 0 {
                 info!("\nFailed games saved for retry with `failed-retry` command.");
             }
+        }
+
+        BaseballCommands::RescrapeGames {
+            ids_file,
+            database_url,
+            output_dir,
+            limit,
+        } => {
+            let content = std::fs::read_to_string(&ids_file)?;
+            let mut game_ids: Vec<&str> = content.lines().map(str::trim).filter(|l| !l.is_empty()).collect();
+            if let Some(n) = limit {
+                game_ids.truncate(n);
+            }
+            if let Some(bad) = game_ids.iter().find(|id| id.len() < 12 || !id.is_ascii()) {
+                return Err(anyhow::anyhow!("Invalid bbref game id: {bad}"));
+            }
+            info!("Rescraping {} games from {}", game_ids.len(), ids_file.display());
+
+            let pool = create_pool(&database_url).await?;
+            info!("Connected to database");
+            run_migrations(&pool).await?;
+
+            let scraper = if let Some(ref dir) = output_dir {
+                std::fs::create_dir_all(dir)?;
+                Scraper::new().with_output_dir(dir)
+            } else {
+                Scraper::new()
+            };
+            let inserter = BoxScoreInserter::new(&pool);
+            let failed_db = FailedScrapesDb::new(&pool);
+
+            let mut total_imported = 0;
+            let mut total_skipped = 0;
+            let mut total_failed = 0;
+
+            // Delete right before re-fetching, in small batches, so the DB
+            // is only ever missing a batch worth of games mid-run.
+            for (i, batch) in game_ids.chunks(50).enumerate() {
+                let urls: Vec<BoxScoreUrl> = batch
+                    .iter()
+                    .map(|id| BoxScoreUrl {
+                        game_id: (*id).to_string(),
+                        // First three characters of a bbref game id are the home team code
+                        path: format!("/boxes/{}/{id}.shtml", &id[..3]),
+                    })
+                    .collect();
+
+                let batch_owned: Vec<String> = batch.iter().map(|id| (*id).to_string()).collect();
+                let deleted = sqlx::query("DELETE FROM games WHERE bbref_game_id = ANY($1)")
+                    .bind(&batch_owned)
+                    .execute(&pool)
+                    .await?;
+                info!("Batch {}: deleted {} existing games", i + 1, deleted.rows_affected());
+
+                let results = scraper
+                    .scrape_all_with_tracking(&urls, &inserter, Some(&failed_db))
+                    .await;
+
+                let summary = summarize_results(&results, &format!("Batch {} Summary", i + 1));
+                total_imported += summary.imported;
+                total_skipped += summary.skipped;
+                total_failed += summary.failed;
+            }
+
+            info!("");
+            info!("{}", "=".repeat(50));
+            info!("=== Rescrape Summary ===");
+            info!("Total Imported: {total_imported}");
+            info!("Total Skipped: {total_skipped}");
+            info!("Total Failed: {total_failed}");
         }
 
         BaseballCommands::FailedList { database_url } => {

--- a/sports/baseballref/src/parser/batting.rs
+++ b/sports/baseballref/src/parser/batting.rs
@@ -47,57 +47,24 @@ pub struct ParsedBattingLine {
 }
 
 /// Parse batting tables for both teams
+///
+/// Table IDs (`LosAngelesDodgersbatting`) contain team names, not codes, so
+/// teams are assigned by document order: bbref always renders the away team's
+/// table first (away bats first).
 pub fn parse_batting_tables(
     doc: &Html,
     comments: &[Html],
     away_team_code: &str,
     home_team_code: &str,
 ) -> Result<Vec<ParsedBattingLine>, String> {
-    let mut all_lines = Vec::new();
+    let tables = super::collect_team_tables(doc, comments, "batting")?;
 
-    // Find batting tables - they're in comments with IDs like "LosAngelesDodgersbatting"
-    // We need to search by partial ID match
-    for comment_doc in comments {
-        let table_selector = Selector::parse("table.stats_table").map_err(|e| format!("{e:?}"))?;
-
-        for table in comment_doc.select(&table_selector) {
-            let table_id = get_attr(table, "id").unwrap_or("");
-
-            // Check if this is a batting table
-            if !table_id.to_lowercase().contains("batting") {
-                continue;
-            }
-
-            // Determine which team this is for based on table ID
-            let team_code = if table_id.to_lowercase().contains(&away_team_code.to_lowercase())
-                || table_id.contains("Dodgers")
-                || table_id.contains("visitor")
-            {
-                away_team_code
-            } else {
-                home_team_code
-            };
-
-            let lines = parse_batting_table(table, team_code)?;
-            all_lines.extend(lines);
-        }
+    if tables.len() != 2 {
+        return Err(format!("expected 2 batting tables, found {}", tables.len()));
     }
 
-    // Also check main document
-    let table_selector = Selector::parse("table.stats_table").map_err(|e| format!("{e:?}"))?;
-    for table in doc.select(&table_selector) {
-        let table_id = get_attr(table, "id").unwrap_or("");
-        if table_id.to_lowercase().contains("batting") {
-            let team_code = if table_id.to_lowercase().contains(&away_team_code.to_lowercase()) {
-                away_team_code
-            } else {
-                home_team_code
-            };
-            let lines = parse_batting_table(table, team_code)?;
-            all_lines.extend(lines);
-        }
-    }
-
+    let mut all_lines = parse_batting_table(tables[0], away_team_code)?;
+    all_lines.extend(parse_batting_table(tables[1], home_team_code)?);
     Ok(all_lines)
 }
 
@@ -260,6 +227,63 @@ fn parse_cwpa(value: &str) -> Option<Decimal> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn batting_table(id: &str, player: &str) -> String {
+        format!(
+            r#"<table class="stats_table" id="{id}"><tbody><tr><th data-append-csv="x01">{player} 2B</th><td data-stat="AB">4</td></tr></tbody></table>"#
+        )
+    }
+
+    #[test]
+    fn test_tables_assigned_by_document_order() {
+        // Away table renders first on bbref; ids carry names, not codes, so
+        // neither id contains its team code (the old id-matching heuristic
+        // misassigned these).
+        let html = format!(
+            "<html><body>{}{}</body></html>",
+            batting_table("SanFranciscoGiantsbatting", "Away Guy"),
+            batting_table("LosAngelesDodgersbatting", "Home Guy"),
+        );
+        let doc = Html::parse_document(&html);
+
+        let lines = parse_batting_tables(&doc, &[], "SFG", "LAD").expect("parses");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            (lines[0].player_name.as_str(), lines[0].team_code.as_str()),
+            ("Away Guy", "SFG")
+        );
+        assert_eq!(
+            (lines[1].player_name.as_str(), lines[1].team_code.as_str()),
+            ("Home Guy", "LAD")
+        );
+    }
+
+    #[test]
+    fn test_commented_tables_take_priority_over_document() {
+        let comment = Html::parse_fragment(&format!(
+            "{}{}",
+            batting_table("MilwaukeeBrewersbatting", "Comment Away"),
+            batting_table("ChicagoCubsbatting", "Comment Home"),
+        ));
+        let doc = Html::parse_document(&format!(
+            "<html><body>{}{}</body></html>",
+            batting_table("MilwaukeeBrewersbatting", "Doc Away"),
+            batting_table("ChicagoCubsbatting", "Doc Home"),
+        ));
+
+        let lines = parse_batting_tables(&doc, &[comment], "MIL", "CHC").expect("parses");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].player_name, "Comment Away");
+    }
+
+    #[test]
+    fn test_wrong_table_count_is_an_error() {
+        let html = format!("<html><body>{}</body></html>", batting_table("OnlyOnebatting", "Solo"));
+        let doc = Html::parse_document(&html);
+
+        let err = parse_batting_tables(&doc, &[], "MIL", "CHC").expect_err("one table must not parse");
+        assert!(err.contains("found 1"), "unexpected error: {err}");
+    }
 
     #[test]
     fn test_parse_simple_position() {

--- a/sports/baseballref/src/parser/box_score.rs
+++ b/sports/baseballref/src/parser/box_score.rs
@@ -164,4 +164,35 @@ mod tests {
         // Verify we got play-by-play
         assert!(!box_score.play_by_play.is_empty());
     }
+
+    #[test]
+    fn test_lad_home_game_team_assignment() {
+        // 2019-03-28 ARI @ LAD opener; cached fixture in the repo-root data dir
+        let path = "../../data/bbref/2019/LAN201903280.shtml";
+        if !Path::new(path).exists() {
+            return;
+        }
+
+        let box_score = BoxScore::from_file(path).expect("Failed to parse box score");
+        let away = &box_score.game_info.away_team_code;
+        let home = &box_score.game_info.home_team_code;
+        assert_eq!(home, "LAD");
+
+        // Both sides must get a full complement of batting and pitching lines
+        let away_bat = box_score.batting_lines.iter().filter(|b| &b.team_code == away).count();
+        let home_bat = box_score.batting_lines.iter().filter(|b| &b.team_code == home).count();
+        assert!(away_bat >= 9, "away batting lines: {away_bat}");
+        assert!(home_bat >= 9, "home batting lines: {home_bat}");
+
+        let home_pitch = box_score.pitching_lines.iter().filter(|p| &p.team_code == home).count();
+        assert!(home_pitch >= 1, "home pitching lines: {home_pitch}");
+
+        // Bottom halves must credit the home team as batting
+        assert!(
+            box_score
+                .play_by_play
+                .iter()
+                .all(|e| e.batting_team_code == if e.is_bottom { home.clone() } else { away.clone() })
+        );
+    }
 }

--- a/sports/baseballref/src/parser/pitching.rs
+++ b/sports/baseballref/src/parser/pitching.rs
@@ -39,56 +39,24 @@ pub struct ParsedPitchingLine {
 }
 
 /// Parse pitching tables for both teams
+///
+/// Table IDs (`LosAngelesDodgerspitching`) contain team names, not codes, so
+/// teams are assigned by document order: bbref always renders the away team's
+/// table first (away bats first).
 pub fn parse_pitching_tables(
     doc: &Html,
     comments: &[Html],
     away_team_code: &str,
     home_team_code: &str,
 ) -> Result<Vec<ParsedPitchingLine>, String> {
-    let mut all_lines = Vec::new();
+    let tables = super::collect_team_tables(doc, comments, "pitching")?;
 
-    // Find pitching tables in comments
-    for comment_doc in comments {
-        let table_selector = Selector::parse("table.stats_table").map_err(|e| format!("{e:?}"))?;
-
-        for table in comment_doc.select(&table_selector) {
-            let table_id = get_attr(table, "id").unwrap_or("");
-
-            // Check if this is a pitching table
-            if !table_id.to_lowercase().contains("pitching") {
-                continue;
-            }
-
-            // Determine which team this is for
-            let team_code = if table_id.to_lowercase().contains(&away_team_code.to_lowercase())
-                || table_id.contains("Dodgers")
-                || table_id.contains("visitor")
-            {
-                away_team_code
-            } else {
-                home_team_code
-            };
-
-            let lines = parse_pitching_table(table, team_code)?;
-            all_lines.extend(lines);
-        }
+    if tables.len() != 2 {
+        return Err(format!("expected 2 pitching tables, found {}", tables.len()));
     }
 
-    // Also check main document
-    let table_selector = Selector::parse("table.stats_table").map_err(|e| format!("{e:?}"))?;
-    for table in doc.select(&table_selector) {
-        let table_id = get_attr(table, "id").unwrap_or("");
-        if table_id.to_lowercase().contains("pitching") {
-            let team_code = if table_id.to_lowercase().contains(&away_team_code.to_lowercase()) {
-                away_team_code
-            } else {
-                home_team_code
-            };
-            let lines = parse_pitching_table(table, team_code)?;
-            all_lines.extend(lines);
-        }
-    }
-
+    let mut all_lines = parse_pitching_table(tables[0], away_team_code)?;
+    all_lines.extend(parse_pitching_table(tables[1], home_team_code)?);
     Ok(all_lines)
 }
 

--- a/sports/baseballref/src/parser/play_by_play.rs
+++ b/sports/baseballref/src/parser/play_by_play.rs
@@ -91,11 +91,16 @@ fn parse_pbp_table(
 
         event_num += 1;
 
+        // Default from the inning half; the batting-team cell overrides it
+        // below when it names a team, which handles relocated "home" games
+        // where the listed home team bats first.
+        let batting_team_code = if is_bottom { home_team_code } else { away_team_code };
+
         let mut event = ParsedPlayByPlay {
             event_num,
             inning,
             is_bottom,
-            batting_team_code: String::new(),
+            batting_team_code: batting_team_code.to_string(),
             batter_name: String::new(),
             batter_bbref_id: None,
             pitcher_name: String::new(),
@@ -146,13 +151,24 @@ fn parse_pbp_table(
                     event.outs_on_play = Some(value.matches('O').count() as i32);
                 }
                 "batting_team_id" => {
-                    // Determine team code
-                    let team = if value.contains("LAD") || is_away_batting(&value, away_team_code) {
-                        away_team_code
-                    } else {
-                        home_team_code
-                    };
-                    event.batting_team_code = team.to_string();
+                    let cell = value.to_uppercase();
+                    let matches_away = cell.contains(&away_team_code.to_uppercase());
+                    let matches_home = cell.contains(&home_team_code.to_uppercase());
+                    match (matches_away, matches_home) {
+                        (true, false) => event.batting_team_code = away_team_code.to_string(),
+                        (false, true) => event.batting_team_code = home_team_code.to_string(),
+                        _ => {
+                            if !value.is_empty() {
+                                tracing::warn!(
+                                    event_num,
+                                    cell = %value,
+                                    away = %away_team_code,
+                                    home = %home_team_code,
+                                    "play-by-play batting-team cell names neither team; using inning half"
+                                );
+                            }
+                        }
+                    }
                 }
                 "batter" => {
                     event.batter_name = value.replace('\u{a0}', " ");
@@ -224,6 +240,77 @@ fn parse_pitch_info(text: &str) -> (Option<i32>, Option<String>) {
     (count, sequence)
 }
 
-fn is_away_batting(team_id: &str, away_code: &str) -> bool {
-    team_id.to_uppercase().contains(&away_code.to_uppercase())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pbp_row(half: &str, team_cell: &str, batter: &str) -> String {
+        format!(
+            r#"<tr><th>{half}</th>
+            <td data-stat="score_batting_team">0-0</td>
+            <td data-stat="outs">0</td>
+            <td data-stat="runners_on_bases_pbp">---</td>
+            <td data-stat="pitches_pbp">3,(1-1) CBX</td>
+            <td data-stat="runs_outs_result">O</td>
+            <td data-stat="batting_team_id">{team_cell}</td>
+            <td data-stat="batter">{batter}</td>
+            <td data-stat="pitcher">Some Pitcher</td>
+            <td data-stat="win_probability_added">-2%</td>
+            <td data-stat="win_expectancy_post">48%</td>
+            <td data-stat="play_desc">Flyball: CF</td></tr>"#
+        )
+    }
+
+    #[test]
+    fn test_batting_team_follows_inning_half() {
+        // The cell text says LAD in both halves; only the inning half decides
+        // (the old contains("LAD") hack marked LAD-home bottom halves as away).
+        let table = format!(
+            r#"<table id="play_by_play"><tbody>{}{}</tbody></table>"#,
+            pbp_row("t1", "SFG", "Away Batter"),
+            pbp_row("b1", "LAD", "Home Batter"),
+        );
+        let comment = Html::parse_fragment(&table);
+        let doc = Html::parse_document("<html><body></body></html>");
+
+        let events = parse_play_by_play(&doc, &[comment], "SFG", "LAD").expect("parses");
+        assert_eq!(events.len(), 2);
+        assert!(!events[0].is_bottom);
+        assert_eq!(events[0].batting_team_code, "SFG");
+        assert!(events[1].is_bottom);
+        assert_eq!(events[1].batting_team_code, "LAD");
+        assert_eq!(events[1].batter_name, "Home Batter");
+    }
+
+    #[test]
+    fn test_relocated_game_trusts_batting_team_cell() {
+        // Relocated "home" games (e.g. 2020 SEA@SDP) have the listed home
+        // team batting first; the cell overrides the inning-half default.
+        let table = format!(
+            r#"<table id="play_by_play"><tbody>{}{}</tbody></table>"#,
+            pbp_row("t1", "SDP", "Displaced Home Batter"),
+            pbp_row("b1", "SEA", "Displaced Away Batter"),
+        );
+        let comment = Html::parse_fragment(&table);
+        let doc = Html::parse_document("<html><body></body></html>");
+
+        let events = parse_play_by_play(&doc, &[comment], "SEA", "SDP").expect("parses");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].batting_team_code, "SDP");
+        assert_eq!(events[1].batting_team_code, "SEA");
+    }
+
+    #[test]
+    fn test_unrecognized_batting_team_cell_falls_back_to_inning_half() {
+        let table = format!(
+            r#"<table id="play_by_play"><tbody>{}</tbody></table>"#,
+            pbp_row("b3", "???", "Some Batter"),
+        );
+        let comment = Html::parse_fragment(&table);
+        let doc = Html::parse_document("<html><body></body></html>");
+
+        let events = parse_play_by_play(&doc, &[comment], "SFG", "LAD").expect("parses");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].batting_team_code, "LAD");
+    }
 }

--- a/sports/baseballref/src/parser/util.rs
+++ b/sports/baseballref/src/parser/util.rs
@@ -41,6 +41,30 @@ pub fn extract_commented_html(html: &str) -> Vec<String> {
     results
 }
 
+/// Collect the per-team stats tables whose id contains `kind` ("batting" /
+/// "pitching"), in document order — bbref renders the away team's table first.
+/// Tables normally live in commented-out HTML; the main document is a fallback
+/// (checking both would double-count).
+pub fn collect_team_tables<'a>(
+    doc: &'a scraper::Html,
+    comments: &'a [scraper::Html],
+    kind: &str,
+) -> Result<Vec<scraper::ElementRef<'a>>, String> {
+    let table_selector = scraper::Selector::parse("table.stats_table").map_err(|e| format!("{e:?}"))?;
+    let matches_kind =
+        |table: &scraper::ElementRef<'a>| get_attr(*table, "id").unwrap_or("").to_lowercase().contains(kind);
+
+    let mut tables: Vec<scraper::ElementRef<'a>> = comments
+        .iter()
+        .flat_map(|comment_doc| comment_doc.select(&table_selector))
+        .filter(matches_kind)
+        .collect();
+    if tables.is_empty() {
+        tables = doc.select(&table_selector).filter(matches_kind).collect();
+    }
+    Ok(tables)
+}
+
 /// Get text content from an element, trimmed
 pub fn get_text(element: scraper::ElementRef<'_>) -> String {
     element.text().collect::<Vec<_>>().join("").trim().to_string()

--- a/sports/baseballref/src/scraper/schedule.rs
+++ b/sports/baseballref/src/scraper/schedule.rs
@@ -70,7 +70,7 @@ fn parse_boxscore_href(href: &str) -> Option<BoxScoreUrl> {
 
     if Path::new(filename)
         .extension()
-        .is_none_or(|ext| ext.eq_ignore_ascii_case("rs"))
+        .is_none_or(|ext| !ext.eq_ignore_ascii_case("shtml"))
     {
         return None;
     }
@@ -85,8 +85,9 @@ fn parse_boxscore_href(href: &str) -> Option<BoxScoreUrl> {
     let team_code = &game_id[..3];
     let rest = &game_id[3..];
 
-    // Team code should be uppercase letters
-    if !team_code.chars().all(|c| c.is_ascii_uppercase()) {
+    // Team code is uppercase letters, with digits in some historical
+    // retrosheet-style codes (WS1, WS2, KC1, SE1, ML4, ...)
+    if !team_code.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()) {
         return None;
     }
 
@@ -118,6 +119,12 @@ mod tests {
         let url = parse_boxscore_href("/boxes/NYA/NYA202507041.shtml");
         assert!(url.is_some());
         assert_eq!(url.unwrap().game_id, "NYA202507041");
+
+        // Historical team codes with digits (expansion Senators, KC Athletics)
+        let url = parse_boxscore_href("/boxes/WS2/WS2196504230.shtml");
+        assert!(url.is_some());
+        assert_eq!(url.unwrap().game_id, "WS2196504230");
+        assert!(parse_boxscore_href("/boxes/KC1/KC1196007150.shtml").is_some());
 
         // Invalid URLs
         assert!(parse_boxscore_href("/boxes/").is_none());


### PR DESCRIPTION
This PR fixes incorrect team assignments in batting and pitching lines caused by a flawed heuristic that attempted to match team codes against HTML table IDs (e.g., `LosAngelesDodgersbatting`). Since those IDs contain full team names rather than codes, the matching frequently failed and fell back to assigning all rows to the home team, or misidentified the Dodgers as the away team.

## Parser fixes

**Batting and pitching table assignment** now relies on document order rather than ID matching. Baseball Reference consistently renders the away team's table first, so the first collected table is assigned the away code and the second the home code. A shared `collect_team_tables` helper in `util.rs` centralizes this logic, preferring commented-out HTML (where bbref hides these tables) and falling back to the main document only when nothing is found in comments.

**Play-by-play batting team assignment** is reworked to default from the inning half (top = away, bottom = home) and override only when the batting-team cell unambiguously matches one of the two team codes. This correctly handles relocated "home" games where the listed home team bats in the top half, while eliminating the previous `contains("LAD")` special-case that caused misassignment for Dodgers home games.

**Schedule parsing** fixes two bugs: the extension filter was inverted (previously filtering *in* `.rs` files instead of filtering *out* non-`.shtml` files), and historical Retrosheet-style team codes containing digits (`WS1`, `WS2`, `KC1`, etc.) are now accepted.

## Data repair

A new SQL script (`repair_team_assignment.sql`) corrects already-ingested rows without requiring a full re-scrape. It identifies the two per-game table blocks by detecting where `batting_order` or `pitch_order` resets, then uses a majority vote against play-by-play data to determine each block's true team. Games where the vote is ambiguous or the blocks can't be cleanly separated are flagged for re-scraping.

## RescrapeGames command

A new `rescrape-games` CLI subcommand accepts a file of bbref game IDs and re-fetches them in batches of 50, deleting existing records immediately before re-fetching each batch to minimize the window where data is absent.