### PR TITLE
Add scorebug game header component to game detail page

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -735,3 +735,73 @@ a.classic-card:hover {
 .picker-results .picker-hit:hover {
     background: var(--bg-hover);
 }
+
+/* Scorebug game header */
+.scorebug {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+}
+
+.scorebug-teams {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.scorebug-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    color: var(--text-dim);
+}
+
+.scorebug-row.winner {
+    color: var(--text);
+}
+
+.scorebug-code {
+    font-weight: 700;
+    font-size: 1.15rem;
+    min-width: 3em;
+}
+
+.scorebug-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.scorebug-score {
+    margin-left: auto;
+    font-size: 1.6rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.scorebug-row.winner .scorebug-score {
+    color: var(--accent);
+}
+
+.scorebug-status {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.2rem;
+}
+
+.scorebug-final {
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--success);
+}

--- a/sports/webui/src/pages/game_detail.rs
+++ b/sports/webui/src/pages/game_detail.rs
@@ -30,14 +30,6 @@ pub fn GameDetail(id: i32) -> Element {
 #[component]
 fn GameDetailView(detail: GameDetailDto) -> Element {
     let g = &detail.game;
-    let title = format!(
-        "{} {} @ {} {} — {}",
-        g.away.code,
-        fmt::score(g.away_score),
-        g.home.code,
-        fmt::score(g.home_score),
-        g.game_date
-    );
     let mut show_pbp = use_signal(|| false);
     let game_id = g.id;
     // Fetched eagerly: the win probability chart needs it, the table stays
@@ -60,7 +52,7 @@ fn GameDetailView(detail: GameDetailDto) -> Element {
     .collect();
 
     rsx! {
-        h1 { "{title}" }
+        ScorebugHeader { game: g.clone() }
         div { class: "game-meta",
             if let Some(venue) = &g.venue {
                 span { "📍 {venue}" }
@@ -453,6 +445,41 @@ fn ScoringSummary(plays: Vec<PlayDto>, home_code: String, away_code: String) -> 
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Scoreboard-style game header: team rows with big scores, winner emphasized
+#[component]
+fn ScorebugHeader(game: crate::dto::GameSummary) -> Element {
+    let away_won = game.away_score.unwrap_or(0) > game.home_score.unwrap_or(0);
+    let home_won = game.home_score.unwrap_or(0) > game.away_score.unwrap_or(0);
+    let decided = away_won || home_won;
+
+    rsx! {
+        div { class: "scorebug",
+            div { class: "scorebug-teams",
+                div { class: if away_won { "scorebug-row winner" } else { "scorebug-row" },
+                    span { class: "scorebug-code",
+                        Link { to: Route::TeamDetail { id: game.away.id }, "{game.away.code}" }
+                    }
+                    span { class: "scorebug-name", "{game.away.name}" }
+                    span { class: "scorebug-score", {fmt::score(game.away_score)} }
+                }
+                div { class: if home_won { "scorebug-row winner" } else { "scorebug-row" },
+                    span { class: "scorebug-code",
+                        Link { to: Route::TeamDetail { id: game.home.id }, "{game.home.code}" }
+                    }
+                    span { class: "scorebug-name", "{game.home.name}" }
+                    span { class: "scorebug-score", {fmt::score(game.home_score)} }
+                }
+            }
+            div { class: "scorebug-status",
+                if decided {
+                    span { class: "scorebug-final", "Final" }
+                }
+                span { class: "muted", "{game.game_date}" }
             }
         }
     }


### PR DESCRIPTION
Replaces the plain text `<h1>` game title on the game detail page with a scoreboard-style header component (`ScorebugHeader`). The new header displays each team in its own row with the team code (linked to the team detail page), full team name, and score in a large tabular font. The winning team's row is visually emphasized with a distinct color, and the winning score is highlighted in the accent color. A "Final" badge appears when the game has a decided outcome, alongside the game date.