### PR TITLE
Improve play-by-play table with mini diamond, inning break rows, and scoring highlights

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -822,3 +822,53 @@ a.classic-card:hover {
 .pos-seq {
     white-space: nowrap;
 }
+
+/* Mini base-state diamond (play-by-play runners column) */
+.mini-diamond svg {
+    width: 22px;
+    height: 22px;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.mini-base {
+    fill: var(--chart-grid);
+    stroke: var(--border);
+}
+
+.mini-base.on {
+    fill: var(--chart-1);
+    stroke: var(--accent);
+}
+
+/* Play-by-play flow */
+.data-table tr.pbp-break td {
+    background: var(--bg-hover);
+    color: var(--text-dim);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.data-table tr.pbp-scoring td {
+    background: rgb(47 137 230 / 8%);
+    color: var(--text);
+    font-weight: 600;
+}
+
+.data-table tr.pbp-scoring td:first-child {
+    box-shadow: inset 3px 0 0 var(--chart-1);
+}
+
+.pbp-run-badge {
+    color: var(--chart-1);
+    font-weight: 700;
+}
+
+.data-table tr.pbp-event td {
+    color: var(--text-dim);
+    font-style: italic;
+}

--- a/sports/webui/src/components/replay/diamond.rs
+++ b/sports/webui/src/components/replay/diamond.rs
@@ -12,6 +12,55 @@ fn base_class(on: bool) -> &'static str {
     if on { "replay-base on" } else { "replay-base" }
 }
 
+fn runners_label(on: [bool; 3]) -> String {
+    let names = ["1st", "2nd", "3rd"];
+    let occupied: Vec<&str> = on.iter().zip(names).filter(|(o, _)| **o).map(|(_, n)| n).collect();
+    match occupied.len() {
+        0 => "bases empty".to_string(),
+        1 => format!("runner on {}", occupied[0]),
+        _ => format!("runners on {}", occupied.join(", ")),
+    }
+}
+
+/// Table-cell-sized base-state glyph: three bases, filled when occupied
+#[component]
+pub fn MiniDiamond(runners: Option<String>) -> Element {
+    let bases = occupied(runners.as_deref());
+    let [first, second, third] = bases;
+    let label = runners_label(bases);
+
+    rsx! {
+        span { class: "mini-diamond", title: "{label}",
+            svg { view_box: "0 0 24 24",
+                rect {
+                    class: if second { "mini-base on" } else { "mini-base" },
+                    x: 8.5,
+                    y: 3.5,
+                    width: 7.0,
+                    height: 7.0,
+                    transform: "rotate(45 12 7)",
+                }
+                rect {
+                    class: if third { "mini-base on" } else { "mini-base" },
+                    x: 3.5,
+                    y: 8.5,
+                    width: 7.0,
+                    height: 7.0,
+                    transform: "rotate(45 7 12)",
+                }
+                rect {
+                    class: if first { "mini-base on" } else { "mini-base" },
+                    x: 13.5,
+                    y: 8.5,
+                    width: 7.0,
+                    height: 7.0,
+                    transform: "rotate(45 17 12)",
+                }
+            }
+        }
+    }
+}
+
 #[component]
 pub(super) fn Diamond(runners: Option<String>) -> Element {
     let [first, second, third] = occupied(runners.as_deref());

--- a/sports/webui/src/components/replay/mod.rs
+++ b/sports/webui/src/components/replay/mod.rs
@@ -3,6 +3,7 @@ mod diamond;
 mod panels;
 mod wp_chart;
 
+pub use diamond::MiniDiamond;
 use dioxus::prelude::*;
 
 use crate::dto::PlayDto;

--- a/sports/webui/src/pages/game_detail.rs
+++ b/sports/webui/src/pages/game_detail.rs
@@ -3,7 +3,7 @@ use dioxus::prelude::*;
 use crate::{
     app::Route,
     bbref,
-    components::replay::ReplayDeck,
+    components::replay::{MiniDiamond, ReplayDeck},
     dto::{BattingLineDto, GameDetailDto, PitchingLineDto, PlayDto},
     fmt, server,
 };
@@ -407,17 +407,29 @@ fn PitchingTable(lines: Vec<PitchingLineDto>, team: String) -> Element {
 
 #[component]
 fn PlayByPlayTable(plays: Vec<PlayDto>) -> Element {
+    /// Ordinal inning label: 1st, 2nd, 3rd, 4th…
+    fn ordinal(n: i32) -> String {
+        let suffix = match (n % 10, n % 100) {
+            (1, 11) | (2, 12) | (3, 13) => "th",
+            (1, _) => "st",
+            (2, _) => "nd",
+            (3, _) => "rd",
+            _ => "th",
+        };
+        format!("{n}{suffix}")
+    }
+
+    let mut prev_half: Option<(i32, bool)> = None;
+
     rsx! {
         div { class: "table-scroll",
             table { class: "data-table",
                 thead {
                     tr {
-                        th { "Inn" }
-                        th { "Team" }
                         th { "Batter" }
                         th { "Pitcher" }
                         th { class: "num", "Outs" }
-                        th { "Runners" }
+                        th { "Bases" }
                         th { class: "num", "Score" }
                         th { class: "num", "Pit" }
                         th { class: "num", "R" }
@@ -428,23 +440,57 @@ fn PlayByPlayTable(plays: Vec<PlayDto>) -> Element {
                 }
                 tbody {
                     for p in plays {
-                        tr { key: "{p.event_num}",
-                            td { {format!("{}{}", if p.is_bottom { "b" } else { "t" }, p.inning)} }
-                            td { "{p.batting_team}" }
-                            td { "{p.batter}" }
-                            td { "{p.pitcher}" }
-                            td { class: "num", {fmt::opt(p.outs_before)} }
-                            td { {p.runners_before.clone().unwrap_or_default()} }
-                            td { class: "num",
-                                {format!("{}–{}", fmt::score(p.score_batting_team), fmt::score(p.score_fielding_team))}
+                        // Half-inning break row when the frame changes
+                        if prev_half != Some((p.inning, p.is_bottom)) {
+                            {
+                                prev_half = Some((p.inning, p.is_bottom));
+                                let half = if p.is_bottom { "▼ Bottom" } else { "▲ Top" };
+                                rsx! {
+                                    tr { class: "pbp-break", key: "break-{p.inning}-{p.is_bottom}",
+                                        td { colspan: 10,
+                                            "{half} of the {ordinal(p.inning)} · {p.batting_team} batting"
+                                        }
+                                    }
+                                }
                             }
-                            td { class: "num", {fmt::opt(p.pitch_count)} }
-                            td { class: "num", {fmt::opt(p.runs_on_play)} }
-                            td { class: "num", {fmt::signed2(p.wpa)} }
-                            td { class: "num",
-                                {p.win_expectancy_after.map_or_else(String::new, |w| format!("{:.0}%", w * 100.0))}
+                        }
+                        {
+                            let scoring = p.runs_on_play.unwrap_or(0) > 0;
+                            let event_only = p
+                                .description
+                                .as_deref()
+                                .is_some_and(crate::server::is_baserunning_only);
+                            let row_class = if scoring {
+                                "pbp-scoring"
+                            } else if event_only {
+                                "pbp-event"
+                            } else {
+                                ""
+                            };
+                            rsx! {
+                                tr { key: "{p.event_num}", class: "{row_class}",
+                                    td { "{p.batter}" }
+                                    td { "{p.pitcher}" }
+                                    td { class: "num", {fmt::opt(p.outs_before)} }
+                                    td {
+                                        MiniDiamond { runners: p.runners_before.clone() }
+                                    }
+                                    td { class: "num",
+                                        {format!("{}–{}", fmt::score(p.score_batting_team), fmt::score(p.score_fielding_team))}
+                                    }
+                                    td { class: "num", {fmt::opt(p.pitch_count)} }
+                                    td { class: "num pbp-runs",
+                                        if scoring {
+                                            span { class: "pbp-run-badge", "+{p.runs_on_play.unwrap_or(0)}" }
+                                        }
+                                    }
+                                    td { class: "num", {fmt::signed2(p.wpa)} }
+                                    td { class: "num",
+                                        {p.win_expectancy_after.map_or_else(String::new, |w| format!("{:.0}%", w * 100.0))}
+                                    }
+                                    td { {p.description.clone().unwrap_or_default()} }
+                                }
                             }
-                            td { {p.description.clone().unwrap_or_default()} }
                         }
                     }
                 }

--- a/sports/webui/src/server/mod.rs
+++ b/sports/webui/src/server/mod.rs
@@ -10,6 +10,7 @@ mod teams;
 pub use dashboard::*;
 pub use games::*;
 pub use leaderboards::*;
+pub(crate) use matchups::is_baserunning_only;
 pub use matchups::*;
 pub use players::*;
 pub use seasons::*;


### PR DESCRIPTION
Redesigns the play-by-play table on the game detail page with improved visual structure and a new base-state glyph.

**Half-inning break rows** are now injected between each change of frame, showing the inning (with ordinal suffix), top/bottom indicator, and the batting team — replacing the redundant "Inn" and "Team" columns that previously appeared on every row.

**Scoring plays** are visually distinguished with a highlighted row background and a left-side accent border. Runs scored are shown as a `+N` badge rather than a plain number. Pure baserunning events are rendered in a dimmed italic style.

**`MiniDiamond` component** replaces the raw runners string in the "Bases" column. It renders a small 22×22 SVG diamond with three rotated squares representing first, second, and third base, filled when occupied. A tooltip provides an accessible text description (e.g. "runners on 1st, 3rd"). The component is backed by the existing `occupied()` parsing logic already used by the full-size replay diamond.