### PR TITLE
Add postseason bracket view and division-grouped standings to season detail page

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -872,3 +872,52 @@ a.classic-card:hover {
     color: var(--text-dim);
     font-style: italic;
 }
+
+/* Postseason bracket */
+.bracket {
+    display: flex;
+    gap: 1.25rem;
+    align-items: stretch;
+    overflow-x: auto;
+    padding: 0.25rem 0;
+}
+
+.bracket-round {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    gap: 0.75rem;
+    min-width: 160px;
+}
+
+.bracket-round-label {
+    color: var(--text-dim);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    text-align: center;
+}
+
+.bracket-card {
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.bracket-team {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+}
+
+.bracket-team.winner {
+    color: var(--text);
+    font-weight: 700;
+}

--- a/sports/webui/src/divisions.rs
+++ b/sports/webui/src/divisions.rs
@@ -1,0 +1,160 @@
+//! Era-aware league/division reference for the franchises in the data
+//! (1950 onward). The schema stores no league/division, and the alignment
+//! changed over time — no divisions before 1969, East/West 1969–1993,
+//! three divisions from 1994 — so this maps (team code, season) to the
+//! alignment that applied that year.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LeagueDiv {
+    pub league: &'static str,
+    pub division: Option<&'static str>,
+}
+
+const fn ld(league: &'static str, division: Option<&'static str>) -> LeagueDiv {
+    LeagueDiv { league, division }
+}
+
+/// League/division for a team code in a given season; `None` for codes or
+/// seasons outside the mapping (callers fall back to ungrouped standings)
+#[allow(clippy::too_many_lines, clippy::match_same_arms)]
+pub fn league_division(code: &str, season: i32) -> Option<LeagueDiv> {
+    let s = season;
+    let al = |div| Some(ld("AL", div));
+    let nl = |div| Some(ld("NL", div));
+
+    // Pre-division era: league only
+    let al_div = |from_1969: &'static str, from_1994: &'static str| {
+        if s < 1969 {
+            al(None)
+        } else if s < 1994 {
+            al(Some(from_1969))
+        } else {
+            al(Some(from_1994))
+        }
+    };
+    let nl_div = |from_1969: &'static str, from_1994: &'static str| {
+        if s < 1969 {
+            nl(None)
+        } else if s < 1994 {
+            nl(Some(from_1969))
+        } else {
+            nl(Some(from_1994))
+        }
+    };
+
+    match code {
+        // ---- American League ----
+        "NYY" => al_div("East", "East"),
+        "BOS" => al_div("East", "East"),
+        "BAL" if s >= 1954 => al_div("East", "East"),
+        "SLB" if (1950..=1953).contains(&s) => al(None),
+        "DET" => {
+            if s < 1969 {
+                al(None)
+            } else if s < 1998 {
+                al(Some("East"))
+            } else {
+                al(Some("Central"))
+            }
+        }
+        "CLE" => al_div("East", "Central"),
+        "CHW" => al_div("West", "Central"),
+        "MIN" if s >= 1961 => al_div("West", "Central"),
+        "WSH" if (1950..=1960).contains(&s) => al(None),
+        "WSA" if (1961..=1971).contains(&s) => {
+            if s < 1969 {
+                al(None)
+            } else {
+                al(Some("East"))
+            }
+        }
+        "TEX" if s >= 1972 => al_div("West", "West"),
+        "KCR" if s >= 1969 => al_div("West", "Central"),
+        "KCA" if (1955..=1967).contains(&s) => al(None),
+        "PHA" if (1950..=1954).contains(&s) => al(None),
+        "OAK" if (1968..=2024).contains(&s) => al_div("West", "West"),
+        "ATH" if s >= 2025 => al(Some("West")),
+        "LAA" if (1961..=1964).contains(&s) => al(None),
+        "CAL" if (1965..=1996).contains(&s) => al_div("West", "West"),
+        "ANA" if (1997..=2004).contains(&s) => al(Some("West")),
+        "LAA" if s >= 2005 => al(Some("West")),
+        "SEP" if s == 1969 => al(Some("West")),
+        "SEA" if s >= 1977 => al_div("West", "West"),
+        "TOR" if s >= 1977 => al_div("East", "East"),
+        "TBD" if (1998..=2007).contains(&s) => al(Some("East")),
+        "TBR" if s >= 2008 => al(Some("East")),
+        // Brewers: AL West 1970-71, AL East 1972-93, AL Central 1994-97,
+        // NL Central from 1998
+        "MIL" if (1970..=1971).contains(&s) => al(Some("West")),
+        "MIL" if (1972..=1993).contains(&s) => al(Some("East")),
+        "MIL" if (1994..=1997).contains(&s) => al(Some("Central")),
+        "MIL" if s >= 1998 => nl(Some("Central")),
+        // Astros: NL through 2012, AL West from 2013
+        "HOU" if (1962..=2012).contains(&s) => nl_div("West", "Central"),
+        "HOU" if s >= 2013 => al(Some("West")),
+
+        // ---- National League ----
+        "BRO" if (1950..=1957).contains(&s) => nl(None),
+        "LAD" if s >= 1958 => nl_div("West", "West"),
+        "NYG" if (1950..=1957).contains(&s) => nl(None),
+        "SFG" if s >= 1958 => nl_div("West", "West"),
+        "CHC" => nl_div("East", "Central"),
+        "STL" => nl_div("East", "Central"),
+        "PIT" => nl_div("East", "Central"),
+        "PHI" => nl_div("East", "East"),
+        "CIN" => nl_div("West", "Central"),
+        "BSN" if (1950..=1952).contains(&s) => nl(None),
+        "MLN" if (1953..=1965).contains(&s) => nl(None),
+        // Braves: NL West 1969-93, NL East from 1994
+        "ATL" if s >= 1966 => nl_div("West", "East"),
+        "NYM" if s >= 1962 => nl_div("East", "East"),
+        "MON" if (1969..=2004).contains(&s) => nl(Some("East")),
+        "WSN" if s >= 2005 => nl(Some("East")),
+        "SDP" if s >= 1969 => nl(Some("West")),
+        "COL" if s >= 1993 => nl(Some("West")),
+        "FLA" if (1993..=2011).contains(&s) => nl(Some("East")),
+        "MIA" if s >= 2012 => nl(Some("East")),
+        "ARI" if s >= 1998 => nl(Some("West")),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn astros_switch_leagues_in_2013() {
+        assert_eq!(league_division("HOU", 2012), Some(ld("NL", Some("Central"))));
+        assert_eq!(league_division("HOU", 2013), Some(ld("AL", Some("West"))));
+        assert_eq!(league_division("HOU", 1968), Some(ld("NL", None)));
+    }
+
+    #[test]
+    fn brewers_wander_the_leagues() {
+        assert_eq!(league_division("MIL", 1970), Some(ld("AL", Some("West"))));
+        assert_eq!(league_division("MIL", 1972), Some(ld("AL", Some("East"))));
+        assert_eq!(league_division("MIL", 1995), Some(ld("AL", Some("Central"))));
+        assert_eq!(league_division("MIL", 1998), Some(ld("NL", Some("Central"))));
+    }
+
+    #[test]
+    fn braves_move_east_in_1994() {
+        assert_eq!(league_division("ATL", 1993), Some(ld("NL", Some("West"))));
+        assert_eq!(league_division("ATL", 1994), Some(ld("NL", Some("East"))));
+    }
+
+    #[test]
+    fn pre_division_era_is_league_only() {
+        assert_eq!(league_division("NYY", 1955), Some(ld("AL", None)));
+        assert_eq!(league_division("BRO", 1955), Some(ld("NL", None)));
+        assert_eq!(league_division("NYY", 1969), Some(ld("AL", Some("East"))));
+    }
+
+    #[test]
+    fn codes_outside_their_era_are_unknown() {
+        assert_eq!(league_division("BRO", 1958), None);
+        assert_eq!(league_division("TEX", 1971), None);
+        assert_eq!(league_division("XXX", 2020), None);
+    }
+}

--- a/sports/webui/src/dto.rs
+++ b/sports/webui/src/dto.rs
@@ -566,6 +566,15 @@ impl PitchingSort {
     }
 }
 
+/// One postseason series, winner first
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BracketSeries {
+    pub winner: TeamRef,
+    pub winner_wins: i64,
+    pub loser: TeamRef,
+    pub loser_wins: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SeasonSummary {
     pub season: i32,

--- a/sports/webui/src/lib.rs
+++ b/sports/webui/src/lib.rs
@@ -5,6 +5,7 @@
 mod app;
 mod bbref;
 mod components;
+mod divisions;
 mod dto;
 mod fmt;
 mod pages;

--- a/sports/webui/src/pages/season_detail.rs
+++ b/sports/webui/src/pages/season_detail.rs
@@ -2,7 +2,8 @@ use dioxus::prelude::*;
 
 use crate::{
     app::Route,
-    dto::{BattingLeaderboardReq, BattingSort, PitchingLeaderboardReq, PitchingSort, format_ip},
+    divisions::league_division,
+    dto::{BattingLeaderboardReq, BattingSort, PitchingLeaderboardReq, PitchingSort, TeamSummary, format_ip},
     fmt,
     pages::games::GamesTable,
     server,
@@ -16,6 +17,7 @@ const MIN_IP: i64 = 40;
 pub fn SeasonDetail(year: i32) -> Element {
     let standings = use_resource(move || server::season_standings(year));
     let postseason = use_resource(move || server::season_postseason_games(year));
+    let bracket = use_resource(move || server::postseason_bracket(year));
     let batting = use_resource(move || {
         server::batting_leaderboard(BattingLeaderboardReq {
             sort: BattingSort::Ops,
@@ -43,46 +45,9 @@ pub fn SeasonDetail(year: i32) -> Element {
             Some(Ok(teams)) if teams.is_empty() => rsx! {
                 div { class: "muted", "No games recorded for {year}." }
             },
-            Some(Ok(teams)) => {
-                let (leader_w, leader_l) = teams.first().map_or((0, 0), |t| (t.wins, t.losses));
-                rsx! {
-                    div { class: "table-scroll",
-                        table { class: "data-table",
-                            thead {
-                                tr {
-                                th { "Team" }
-                                th { class: "num", "G" }
-                                th { class: "num", "W" }
-                                th { class: "num", "L" }
-                                th { class: "num", "PCT" }
-                                th { class: "num", "GB" }
-                                th { class: "num", "RF" }
-                                th { class: "num", "RA" }
-                                th { class: "num", "Diff" }
-                            }
-                        }
-                        tbody {
-                            for t in teams.clone() {
-                                tr { key: "{t.team.id}",
-                                    td {
-                                        Link { to: Route::TeamDetail { id: t.team.id }, "{t.team.code}" }
-                                        span { class: "muted", " {t.team.name}" }
-                                    }
-                                    td { class: "num", "{t.games}" }
-                                    td { class: "num", "{t.wins}" }
-                                    td { class: "num", "{t.losses}" }
-                                    td { class: "num", {win_pct(t.wins, t.losses)} }
-                                    td { class: "num", {games_behind(leader_w, leader_l, t.wins, t.losses)} }
-                                    td { class: "num", "{t.runs_for}" }
-                                    td { class: "num", "{t.runs_against}" }
-                                    td { class: "num", "{t.runs_for - t.runs_against}" }
-                                }
-                            }
-                        }
-                    }
-                }
-                }
-            }
+            Some(Ok(teams)) => rsx! {
+                StandingsSection { teams: teams.clone(), year }
+            },
             Some(Err(e)) => rsx! {
                 div { class: "error-box", "Failed to load standings: {e}" }
             },
@@ -192,15 +157,211 @@ pub fn SeasonDetail(year: i32) -> Element {
             Link { to: Route::Leaderboards { season: Some(year) }, "Full {year} leaderboards →" }
         }
 
+        match &*bracket.read() {
+            Some(Ok(rounds)) if !rounds.is_empty() => rsx! {
+                h2 { "Postseason" }
+                Bracket { rounds: rounds.clone() }
+            },
+            _ => rsx! {},
+        }
+
         match &*postseason.read() {
             Some(Ok(games)) if !games.is_empty() => rsx! {
-                h2 { "Postseason" }
+                h2 { class: "muted", "Postseason games" }
                 GamesTable { games: games.clone() }
             },
             Some(Err(e)) => rsx! {
                 div { class: "error-box", "Failed to load postseason games: {e}" }
             },
             _ => rsx! {},
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum StandingsView {
+    Division,
+    League,
+    Overall,
+}
+
+/// Standings grouped by division (default), league, or ungrouped — with
+/// games-behind computed within each group
+#[component]
+fn StandingsSection(teams: Vec<TeamSummary>, year: i32) -> Element {
+    let mut view = use_signal(|| StandingsView::Division);
+
+    let mapped: Vec<(TeamSummary, Option<crate::divisions::LeagueDiv>)> = teams
+        .iter()
+        .map(|t| (t.clone(), league_division(&t.team.code, year)))
+        .collect();
+    let all_mapped = mapped.iter().all(|(_, m)| m.is_some());
+    let has_divisions = mapped.iter().any(|(_, m)| m.is_some_and(|m| m.division.is_some()));
+
+    let effective = if !all_mapped {
+        StandingsView::Overall
+    } else if view() == StandingsView::Division && !has_divisions {
+        StandingsView::League
+    } else {
+        view()
+    };
+
+    // Build (title, rows) groups; teams arrive sorted by winning percentage,
+    // so filtered groups stay sorted
+    let division_rank = |d: Option<&str>| match d {
+        Some("East") => 0,
+        Some("Central") => 1,
+        Some("West") => 2,
+        _ => 3,
+    };
+    let groups: Vec<(String, Vec<TeamSummary>)> = match effective {
+        StandingsView::Overall => vec![(String::new(), teams.clone())],
+        StandingsView::League => ["AL", "NL"]
+            .iter()
+            .map(|league| {
+                let rows = mapped
+                    .iter()
+                    .filter(|(_, m)| m.is_some_and(|m| m.league == *league))
+                    .map(|(t, _)| t.clone())
+                    .collect::<Vec<_>>();
+                (
+                    if *league == "AL" {
+                        "American League".to_string()
+                    } else {
+                        "National League".to_string()
+                    },
+                    rows,
+                )
+            })
+            .filter(|(_, rows)| !rows.is_empty())
+            .collect(),
+        StandingsView::Division => {
+            let mut keys: Vec<(&str, Option<&str>)> = mapped
+                .iter()
+                .filter_map(|(_, m)| m.map(|m| (m.league, m.division)))
+                .collect();
+            keys.sort_by_key(|(l, d)| (*l != "AL", division_rank(*d)));
+            keys.dedup();
+            keys.into_iter()
+                .map(|(league, division)| {
+                    let rows = mapped
+                        .iter()
+                        .filter(|(_, m)| m.is_some_and(|m| m.league == league && m.division == division))
+                        .map(|(t, _)| t.clone())
+                        .collect::<Vec<_>>();
+                    let title = division.map_or_else(|| league.to_string(), |d| format!("{league} {d}"));
+                    (title, rows)
+                })
+                .collect()
+        }
+    };
+
+    rsx! {
+        if all_mapped {
+            div { class: "tabs",
+                if has_divisions {
+                    button {
+                        class: if effective == StandingsView::Division { "active" } else { "" },
+                        onclick: move |_| view.set(StandingsView::Division),
+                        "Division"
+                    }
+                }
+                button {
+                    class: if effective == StandingsView::League { "active" } else { "" },
+                    onclick: move |_| view.set(StandingsView::League),
+                    "League"
+                }
+                button {
+                    class: if effective == StandingsView::Overall { "active" } else { "" },
+                    onclick: move |_| view.set(StandingsView::Overall),
+                    "Overall"
+                }
+            }
+        }
+        for (title , rows) in groups {
+            if !title.is_empty() {
+                h2 { class: "muted", "{title}" }
+            }
+            StandingsTable { rows }
+        }
+    }
+}
+
+#[component]
+fn StandingsTable(rows: Vec<TeamSummary>) -> Element {
+    let (leader_w, leader_l) = rows.first().map_or((0, 0), |t| (t.wins, t.losses));
+    rsx! {
+        div { class: "table-scroll",
+            table { class: "data-table",
+                thead {
+                    tr {
+                        th { "Team" }
+                        th { class: "num", "G" }
+                        th { class: "num", "W" }
+                        th { class: "num", "L" }
+                        th { class: "num", "PCT" }
+                        th { class: "num", "GB" }
+                        th { class: "num", "RF" }
+                        th { class: "num", "RA" }
+                        th { class: "num", "Diff" }
+                    }
+                }
+                tbody {
+                    for t in rows {
+                        tr { key: "{t.team.id}",
+                            td {
+                                Link { to: Route::TeamDetail { id: t.team.id }, "{t.team.code}" }
+                                span { class: "muted", " {t.team.name}" }
+                            }
+                            td { class: "num", "{t.games}" }
+                            td { class: "num", "{t.wins}" }
+                            td { class: "num", "{t.losses}" }
+                            td { class: "num", {win_pct(t.wins, t.losses)} }
+                            td { class: "num", {games_behind(leader_w, leader_l, t.wins, t.losses)} }
+                            td { class: "num", "{t.runs_for}" }
+                            td { class: "num", "{t.runs_against}" }
+                            td { class: "num", "{t.runs_for - t.runs_against}" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Postseason series columns, earliest round on the left, champion bolded
+#[component]
+fn Bracket(rounds: Vec<Vec<crate::dto::BracketSeries>>) -> Element {
+    let total = rounds.len();
+    let round_label = |i: usize| -> &'static str {
+        match total - 1 - i {
+            0 => "World Series",
+            1 => "Championship",
+            2 => "Division Series",
+            3 => "Wild Card",
+            _ => "Play-in",
+        }
+    };
+
+    rsx! {
+        div { class: "bracket",
+            for (i , round) in rounds.into_iter().enumerate() {
+                div { class: "bracket-round", key: "{i}",
+                    div { class: "bracket-round-label", {round_label(i)} }
+                    for (j , s) in round.into_iter().enumerate() {
+                        div { class: "bracket-card", key: "{i}-{j}",
+                            div { class: "bracket-team winner",
+                                Link { to: Route::TeamDetail { id: s.winner.id }, "{s.winner.code}" }
+                                span { class: "num", "{s.winner_wins}" }
+                            }
+                            div { class: "bracket-team",
+                                Link { to: Route::TeamDetail { id: s.loser.id }, "{s.loser.code}" }
+                                span { class: "num", "{s.loser_wins}" }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -215,7 +376,7 @@ fn win_pct(wins: i64, losses: i64) -> String {
     format!("{pct:.3}")
 }
 
-/// Games behind the standings leader; the leader shows an em dash
+/// Games behind the group leader; the leader shows an em dash
 fn games_behind(leader_w: i64, leader_l: i64, wins: i64, losses: i64) -> String {
     let halves = (leader_w - wins) + (losses - leader_l);
     if halves <= 0 {

--- a/sports/webui/src/server/seasons.rs
+++ b/sports/webui/src/server/seasons.rs
@@ -148,3 +148,158 @@ pub async fn season_postseason_games(year: i32) -> Result<Vec<GameSummary>, Serv
 
     Ok(db_rows.into_iter().map(rows::GameSummaryRow::into_dto).collect())
 }
+
+/// Postseason series grouped into rounds (earliest round first, World Series
+/// last), reconstructed by chaining backward from the latest series: each
+/// participant's immediately-preceding series belongs to the prior round.
+#[server]
+#[allow(clippy::too_many_lines)]
+pub async fn postseason_bracket(year: i32) -> Result<Vec<Vec<crate::dto::BracketSeries>>, ServerFnError> {
+    use std::collections::HashMap;
+
+    use crate::dto::{BracketSeries, TeamRef};
+
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        game_date: chrono::NaiveDate,
+        home_id: i32,
+        home_code: String,
+        home_name: String,
+        away_id: i32,
+        away_code: String,
+        away_name: String,
+        home_score: i32,
+        away_score: i32,
+    }
+
+    struct Series {
+        teams: [TeamRef; 2],
+        wins: [i64; 2],
+        first: chrono::NaiveDate,
+        last: chrono::NaiveDate,
+    }
+
+    let pool = crate::pool().await?;
+    let db_rows: Vec<Row> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        r"
+        WITH regular_end AS ({regular_end})
+        SELECT g.game_date,
+               th.id AS home_id, th.code AS home_code, th.name AS home_name,
+               ta.id AS away_id, ta.code AS away_code, ta.name AS away_name,
+               g.home_score, g.away_score
+        FROM games g
+        JOIN teams th ON th.id = g.home_team_id
+        JOIN teams ta ON ta.id = g.away_team_id
+        JOIN regular_end re ON re.season = EXTRACT(YEAR FROM g.game_date)::int4
+        WHERE EXTRACT(YEAR FROM g.game_date)::int4 = $1
+          AND g.game_date > re.end_date
+          AND g.home_score IS NOT NULL AND g.away_score IS NOT NULL
+          AND g.home_score <> g.away_score
+        ORDER BY g.game_date, g.id
+        ",
+        regular_end = super::REGULAR_SEASON_END
+    )))
+    .bind(year)
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    // Group games into series by team pair
+    let mut series: HashMap<(i32, i32), Series> = HashMap::new();
+    for r in db_rows {
+        let key = (r.home_id.min(r.away_id), r.home_id.max(r.away_id));
+        let entry = series.entry(key).or_insert_with(|| Series {
+            teams: [
+                TeamRef {
+                    id: r.home_id,
+                    code: r.home_code.clone(),
+                    name: r.home_name.clone(),
+                },
+                TeamRef {
+                    id: r.away_id,
+                    code: r.away_code.clone(),
+                    name: r.away_name.clone(),
+                },
+            ],
+            wins: [0, 0],
+            first: r.game_date,
+            last: r.game_date,
+        });
+        let home_won = r.home_score > r.away_score;
+        let winner_id = if home_won { r.home_id } else { r.away_id };
+        let idx = usize::from(entry.teams[1].id == winner_id);
+        entry.wins[idx] += 1;
+        entry.first = entry.first.min(r.game_date);
+        entry.last = entry.last.max(r.game_date);
+    }
+
+    let mut remaining: Vec<Series> = series.into_values().collect();
+    if remaining.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Backward chain: the latest-ending series is the final round
+    let mut rounds_rev: Vec<Vec<Series>> = Vec::new();
+    let final_idx = remaining
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, s)| s.last)
+        .map(|(i, _)| i)
+        .expect("nonempty");
+    let mut current = vec![remaining.swap_remove(final_idx)];
+
+    while !current.is_empty() {
+        // Predecessors: for each participant of the current round, their
+        // latest earlier series
+        let mut pred_indices: Vec<usize> = Vec::new();
+        for s in &current {
+            for team in &s.teams {
+                let best = remaining
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, cand)| cand.last < s.first && cand.teams.iter().any(|t| t.id == team.id))
+                    .max_by_key(|(_, cand)| cand.last)
+                    .map(|(i, _)| i);
+                if let Some(i) = best
+                    && !pred_indices.contains(&i)
+                {
+                    pred_indices.push(i);
+                }
+            }
+        }
+        rounds_rev.push(std::mem::take(&mut current));
+        pred_indices.sort_unstable_by(|a, b| b.cmp(a));
+        for i in pred_indices {
+            current.push(remaining.swap_remove(i));
+        }
+    }
+
+    Ok(rounds_rev
+        .into_iter()
+        .rev()
+        .map(|round| {
+            round
+                .into_iter()
+                .map(|s| {
+                    let [a, b] = s.teams;
+                    let [wa, wb] = s.wins;
+                    if wa >= wb {
+                        BracketSeries {
+                            winner: a,
+                            winner_wins: wa,
+                            loser: b,
+                            loser_wins: wb,
+                        }
+                    } else {
+                        BracketSeries {
+                            winner: b,
+                            winner_wins: wb,
+                            loser: a,
+                            loser_wins: wa,
+                        }
+                    }
+                })
+                .collect()
+        })
+        .collect())
+}


### PR DESCRIPTION
Adds a postseason bracket view and grouped standings to the season detail page.

The season detail page now displays a visual postseason bracket above the raw game log. A new `postseason_bracket` server function queries postseason games, groups them into series by team pair, and reconstructs round structure by chaining backward from the final series. Each round is rendered as a column of cards showing the winner (bolded) and loser with their respective win counts, with round labels derived from distance to the championship (Wild Card, Division Series, Championship, World Series).

Standings are refactored into a `StandingsSection` component that lets users toggle between Division, League, and Overall views. A new `divisions` module provides an era-aware lookup from team code and season year to league and division, covering franchise moves, rebrands, and realignment from 1950 onward (including edge cases like the Astros' 2013 AL move and the Brewers' multi-decade wandering). Games-behind is now computed within each group rather than across the full field. The Division tab is hidden in pre-1969 seasons when no divisions existed, and the toggle is suppressed entirely when team codes fall outside the mapping.