### PR TITLE
Add Stars of the Game component and season schedule grid styles

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -921,3 +921,64 @@ a.classic-card:hover {
     color: var(--text);
     font-weight: 700;
 }
+
+/* Stars of the game */
+.game-stars {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.25rem;
+    margin: 0.5rem 0 1rem;
+}
+
+.game-stars-label {
+    color: var(--chart-3);
+    font-weight: 700;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-right: 0.5rem;
+}
+
+.game-star-wpa {
+    color: var(--chart-2);
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+}
+
+/* Team season schedule grid */
+.sched-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+    margin: 0.75rem 0 1rem;
+}
+
+a.sched-cell {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 3px;
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--text-dim);
+    background: var(--bg-hover);
+    border: 1px solid transparent;
+}
+
+a.sched-cell:hover {
+    text-decoration: none;
+    border-color: var(--accent);
+}
+
+a.sched-cell.win {
+    background: rgb(34 163 133 / 22%);
+    color: var(--chart-2);
+}
+
+a.sched-cell.loss {
+    background: rgb(255 107 107 / 14%);
+    color: var(--error);
+}

--- a/sports/webui/src/pages/game_detail.rs
+++ b/sports/webui/src/pages/game_detail.rs
@@ -86,6 +86,8 @@ fn GameDetailView(detail: GameDetailDto) -> Element {
             div { class: "muted", {decisions.join(" · ")} }
         }
 
+        StarsOfTheGame { detail: detail.clone() }
+
         LineScoreTable { detail: detail.clone() }
 
         match &*pbp.read() {
@@ -604,6 +606,68 @@ fn ScorebugHeader(game: crate::dto::GameSummary) -> Element {
                     span { class: "scorebug-final", "Final" }
                 }
                 span { class: "muted", "{game.game_date}" }
+            }
+        }
+    }
+}
+
+/// Top WPA performers across both box scores — who actually swung the game
+#[component]
+fn StarsOfTheGame(detail: GameDetailDto) -> Element {
+    struct Star {
+        player_id: i32,
+        name: String,
+        context: String,
+        wpa: f64,
+    }
+
+    let mut stars: Vec<Star> = Vec::new();
+    for b in &detail.batting {
+        if let Some(wpa) = b.wpa {
+            let mut context = format!("{}-{}", b.h.unwrap_or(0), b.ab.unwrap_or(0));
+            if let Some(details) = &b.details
+                && !details.is_empty()
+            {
+                context.push_str(", ");
+                context.push_str(details);
+            }
+            stars.push(Star {
+                player_id: b.player_id,
+                name: b.player.clone(),
+                context,
+                wpa,
+            });
+        }
+    }
+    for p in &detail.pitching {
+        if let Some(wpa) = p.wpa {
+            stars.push(Star {
+                player_id: p.player_id,
+                name: p.player.clone(),
+                context: format!("{} IP, {} ER", fmt::ip(p.ip), p.er.unwrap_or(0)),
+                wpa,
+            });
+        }
+    }
+    stars.sort_by(|a, b| b.wpa.total_cmp(&a.wpa));
+    stars.truncate(3);
+    if stars.is_empty() {
+        return rsx! {};
+    }
+
+    rsx! {
+        div { class: "game-stars",
+            span { class: "game-stars-label", "★ Stars" }
+            for (i , s) in stars.into_iter().enumerate() {
+                span { class: "game-star", key: "{s.player_id}",
+                    if i > 0 {
+                        span { class: "muted", " · " }
+                    }
+                    Link { to: Route::PlayerDetail { id: s.player_id }, "{s.name}" }
+                    span { class: "muted", " ({s.context} · " }
+                    span { class: "game-star-wpa", {fmt::signed2(Some(s.wpa))} }
+                    span { class: "muted", ")" }
+                }
             }
         }
     }


### PR DESCRIPTION
Adds a "Stars of the Game" section to the game detail page that highlights the top WPA performers from both the batting and pitching box scores.

The component collects WPA values from all batters and pitchers, sorts them in descending order, and displays the top three. Batters show their hit/at-bat line along with any notable details, while pitchers show innings pitched and earned runs. Each star links to the player's detail page and displays their WPA contribution inline.

Supporting CSS is added for the stars display as well as a compact season schedule grid (win/loss cells) intended for use on team or player pages.