### PR TITLE
Add pitcher splits (home/road and by opponent) to player detail page

### DIFF
--- a/sports/webui/src/dto.rs
+++ b/sports/webui/src/dto.rs
@@ -374,6 +374,24 @@ pub struct SplitRow {
     pub ops: Option<f64>,
 }
 
+/// One pitching split line (home/road or vs one opponent)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PitcherSplitRow {
+    pub label: String,
+    pub games: i64,
+    pub outs: i64,
+    pub so: i64,
+    pub bb: i64,
+    pub era: Option<f64>,
+    pub whip: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PitcherSplitsDto {
+    pub home_away: Vec<PitcherSplitRow>,
+    pub vs_team: Vec<PitcherSplitRow>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PlayerSplitsDto {
     pub home_away: Vec<SplitRow>,

--- a/sports/webui/src/pages/player_detail.rs
+++ b/sports/webui/src/pages/player_detail.rs
@@ -32,6 +32,7 @@ pub fn PlayerDetail(id: i32) -> Element {
     });
 
     let splits = use_resource(move || server::player_batting_splits(id));
+    let pitch_splits = use_resource(move || server::player_pitching_splits(id));
 
     rsx! {
         match &*detail.read() {
@@ -132,6 +133,17 @@ pub fn PlayerDetail(id: i32) -> Element {
                 div { class: "chart-row",
                     SplitTable { title: "Home / road".to_string(), rows: s.home_away.clone() }
                     SplitTable { title: "By opponent (min 10 PA)".to_string(), rows: s.vs_team.clone() }
+                }
+            },
+            _ => rsx! {},
+        }
+
+        match &*pitch_splits.read() {
+            Some(Ok(s)) if !s.home_away.is_empty() => rsx! {
+                h2 { "Pitching splits" }
+                div { class: "chart-row",
+                    PitcherSplitTable { title: "Home / road".to_string(), rows: s.home_away.clone() }
+                    PitcherSplitTable { title: "By opponent (min 10 IP)".to_string(), rows: s.vs_team.clone() }
                 }
             },
             _ => rsx! {},
@@ -432,6 +444,46 @@ fn SplitTable(title: String, rows: Vec<crate::dto::SplitRow>) -> Element {
                                 td { class: "num", {fmt::rate3(row.obp)} }
                                 td { class: "num", {fmt::rate3(row.slg)} }
                                 td { class: "num", {fmt::rate3(row.ops)} }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn PitcherSplitTable(title: String, rows: Vec<crate::dto::PitcherSplitRow>) -> Element {
+    if rows.is_empty() {
+        return rsx! {};
+    }
+    rsx! {
+        div {
+            h2 { class: "muted", "{title}" }
+            div { class: "table-scroll",
+                table { class: "data-table",
+                    thead {
+                        tr {
+                            th { "" }
+                            th { class: "num", "G" }
+                            th { class: "num", "IP" }
+                            th { class: "num", "SO" }
+                            th { class: "num", "BB" }
+                            th { class: "num", "ERA" }
+                            th { class: "num", "WHIP" }
+                        }
+                    }
+                    tbody {
+                        for row in rows {
+                            tr { key: "{row.label}",
+                                td { "{row.label}" }
+                                td { class: "num", "{row.games}" }
+                                td { class: "num", {format_ip(row.outs)} }
+                                td { class: "num", "{row.so}" }
+                                td { class: "num", "{row.bb}" }
+                                td { class: "num", {fmt::num2(row.era)} }
+                                td { class: "num", {fmt::num2(row.whip)} }
                             }
                         }
                     }

--- a/sports/webui/src/server/players.rs
+++ b/sports/webui/src/server/players.rs
@@ -692,3 +692,91 @@ pub async fn player_pitching_seasons(player_id: i32) -> Result<Vec<crate::dto::P
         })
         .collect())
 }
+
+/// Home/road and vs-opponent pitching splits (career, all games)
+#[server]
+pub async fn player_pitching_splits(player_id: i32) -> Result<crate::dto::PitcherSplitsDto, ServerFnError> {
+    use crate::dto::{PitcherSplitRow, PitcherSplitsDto};
+
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        label: String,
+        games: i64,
+        outs: i64,
+        so: i64,
+        bb: i64,
+        era: Option<f64>,
+        whip: Option<f64>,
+    }
+
+    fn into_split(r: Row) -> PitcherSplitRow {
+        PitcherSplitRow {
+            label: r.label,
+            games: r.games,
+            outs: r.outs,
+            so: r.so,
+            bb: r.bb,
+            era: r.era,
+            whip: r.whip,
+        }
+    }
+
+    const AGG: &str = r"
+        COUNT(*) AS games,
+        COALESCE(SUM(FLOOR(pl.ip) * 3 + ROUND((pl.ip - FLOOR(pl.ip)) * 10)), 0)::bigint AS outs,
+        COALESCE(SUM(pl.so), 0)::bigint AS so,
+        COALESCE(SUM(pl.bb), 0)::bigint AS bb,
+        COALESCE(SUM(pl.h), 0)::bigint AS h,
+        COALESCE(SUM(pl.er), 0)::bigint AS er";
+
+    let pool = crate::pool().await?;
+
+    let home_away: Vec<Row> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        r"
+        SELECT label, games, outs, so, bb,
+               CASE WHEN outs > 0 THEN er::float8 * 27.0 / outs::float8 END AS era,
+               CASE WHEN outs > 0 THEN (bb + h)::float8 * 3.0 / outs::float8 END AS whip
+        FROM (
+            SELECT CASE WHEN pl.team_id = g.home_team_id THEN 'Home' ELSE 'Road' END AS label,
+                   {AGG}
+            FROM pitching_lines pl
+            JOIN games g ON g.id = pl.game_id
+            WHERE pl.player_id = $1
+            GROUP BY 1
+        ) totals
+        ORDER BY label
+        "
+    )))
+    .bind(player_id)
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    let vs_team: Vec<Row> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        r"
+        SELECT label, games, outs, so, bb,
+               CASE WHEN outs > 0 THEN er::float8 * 27.0 / outs::float8 END AS era,
+               CASE WHEN outs > 0 THEN (bb + h)::float8 * 3.0 / outs::float8 END AS whip
+        FROM (
+            SELECT t.code AS label,
+                   {AGG}
+            FROM pitching_lines pl
+            JOIN games g ON g.id = pl.game_id
+            JOIN teams t ON t.id = CASE WHEN pl.team_id = g.home_team_id THEN g.away_team_id ELSE g.home_team_id END
+            WHERE pl.player_id = $1
+            GROUP BY t.code
+        ) totals
+        WHERE outs >= 30
+        ORDER BY outs DESC
+        "
+    )))
+    .bind(player_id)
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    Ok(PitcherSplitsDto {
+        home_away: home_away.into_iter().map(into_split).collect(),
+        vs_team: vs_team.into_iter().map(into_split).collect(),
+    })
+}


### PR DESCRIPTION
## Add pitching splits to player detail page

Introduces career pitching splits (home/road and by opponent) on the player detail page, mirroring the existing batting splits section.

### Changes

- Added `PitcherSplitRow` and `PitcherSplitsDto` DTOs to represent pitching split data, including games, outs, strikeouts, walks, ERA, and WHIP.
- Added a `player_pitching_splits` server function that queries home/road splits and per-opponent splits (minimum 10 IP) from `pitching_lines`, computing ERA and WHIP from raw totals.
- Added a `PitcherSplitTable` component that renders a split table with columns for G, IP, SO, BB, ERA, and WHIP.
- Wired up the new resource and table on the player detail page, displayed only when pitching split data is available.