### PR TITLE
Add all-time head-to-head record grid to team detail page

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -982,3 +982,51 @@ a.sched-cell.loss {
     background: rgb(255 107 107 / 14%);
     color: var(--error);
 }
+
+/* Head-to-head grid */
+.h2h-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 0.5rem;
+    margin: 0.75rem 0 1rem;
+}
+
+a.h2h-card {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    background: var(--bg-panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.45rem 0.65rem;
+    color: var(--text);
+}
+
+a.h2h-card:hover {
+    text-decoration: none;
+    border-color: var(--accent);
+}
+
+.h2h-code {
+    font-weight: 700;
+}
+
+.h2h-record {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.h2h-record.up {
+    color: var(--chart-2);
+}
+
+.h2h-record.down {
+    color: var(--error);
+}
+
+.h2h-pct {
+    margin-left: auto;
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+}

--- a/sports/webui/src/dto.rs
+++ b/sports/webui/src/dto.rs
@@ -438,6 +438,14 @@ impl PlayerBrowseSort {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HeadToHeadRow {
+    pub opponent: TeamRef,
+    pub games: i64,
+    pub wins: i64,
+    pub losses: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TeamSeasonRow {
     pub season: i32,
     pub games: i64,

--- a/sports/webui/src/pages/team_detail.rs
+++ b/sports/webui/src/pages/team_detail.rs
@@ -13,6 +13,7 @@ use crate::{
 pub fn TeamDetail(id: i32) -> Element {
     let detail = use_resource(move || server::team_detail(id));
     let seasons = use_resource(move || server::team_seasons(id));
+    let h2h = use_resource(move || server::team_head_to_head(id));
 
     rsx! {
         match &*detail.read() {
@@ -52,6 +53,13 @@ pub fn TeamDetail(id: i32) -> Element {
             },
             Some(Err(e)) => rsx! {
                 div { class: "error-box", "Failed to load seasons: {e}" }
+            },
+            _ => rsx! {},
+        }
+
+        match &*h2h.read() {
+            Some(Ok(rows)) if !rows.is_empty() => rsx! {
+                HeadToHead { rows: rows.clone() }
             },
             _ => rsx! {},
         }
@@ -384,6 +392,29 @@ fn StatCard(label: String, value: String) -> Element {
         div { class: "stat-card",
             div { class: "stat-value", "{value}" }
             div { class: "stat-label", "{label}" }
+        }
+    }
+}
+
+/// All-time record against every opponent, as a compact card grid
+#[component]
+fn HeadToHead(rows: Vec<crate::dto::HeadToHeadRow>) -> Element {
+    rsx! {
+        h2 { "Head to head (all-time)" }
+        div { class: "h2h-grid",
+            for r in rows {
+                Link {
+                    to: Route::TeamDetail { id: r.opponent.id },
+                    class: "h2h-card",
+                    key: "{r.opponent.id}",
+                    span { class: "h2h-code", "{r.opponent.code}" }
+                    span {
+                        class: if r.wins >= r.losses { "h2h-record up" } else { "h2h-record down" },
+                        "{r.wins}–{r.losses}"
+                    }
+                    span { class: "h2h-pct", {win_pct(r.wins, r.losses)} }
+                }
+            }
         }
     }
 }

--- a/sports/webui/src/server/teams.rs
+++ b/sports/webui/src/server/teams.rs
@@ -325,3 +325,56 @@ pub async fn team_schedule(team_id: i32, season: i32) -> Result<Vec<crate::dto::
         .map_err(super::db_err)?;
     Ok(db_rows.into_iter().map(rows::GameSummaryRow::into_dto).collect())
 }
+
+/// All-time W-L against every opponent
+#[server]
+pub async fn team_head_to_head(team_id: i32) -> Result<Vec<crate::dto::HeadToHeadRow>, ServerFnError> {
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        opponent_id: i32,
+        code: String,
+        name: String,
+        games: i64,
+        wins: i64,
+        losses: i64,
+    }
+
+    let pool = crate::pool().await?;
+    let db_rows: Vec<Row> = sqlx::query_as(
+        r"
+        SELECT t.id AS opponent_id, t.code, t.name,
+               COUNT(*) AS games,
+               COUNT(*) FILTER (
+                   WHERE (g.home_team_id = $1 AND g.home_score > g.away_score)
+                      OR (g.away_team_id = $1 AND g.away_score > g.home_score)
+               ) AS wins,
+               COUNT(*) FILTER (
+                   WHERE (g.home_team_id = $1 AND g.home_score < g.away_score)
+                      OR (g.away_team_id = $1 AND g.away_score < g.home_score)
+               ) AS losses
+        FROM games g
+        JOIN teams t ON t.id = CASE WHEN g.home_team_id = $1 THEN g.away_team_id ELSE g.home_team_id END
+        WHERE g.home_team_id = $1 OR g.away_team_id = $1
+        GROUP BY t.id, t.code, t.name
+        ORDER BY games DESC
+        ",
+    )
+    .bind(team_id)
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    Ok(db_rows
+        .into_iter()
+        .map(|r| crate::dto::HeadToHeadRow {
+            opponent: crate::dto::TeamRef {
+                id: r.opponent_id,
+                code: r.code,
+                name: r.name,
+            },
+            games: r.games,
+            wins: r.wins,
+            losses: r.losses,
+        })
+        .collect())
+}


### PR DESCRIPTION
Adds an all-time head-to-head record section to the team detail page. A new `team_head_to_head` server function queries the database to calculate wins and losses against every opponent the team has faced, grouped and ordered by number of games played. The results are surfaced through a new `HeadToHeadRow` DTO and rendered as a compact card grid, where each card links to the opponent's detail page and displays their team code, W–L record (colored green or red depending on the winning record), and win percentage.