### PR TITLE
Add navbar omnibox for searching players and teams

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -1030,3 +1030,52 @@ a.h2h-card:hover {
     font-size: 0.8rem;
     font-variant-numeric: tabular-nums;
 }
+
+/* Navbar omnibox */
+.omni {
+    position: relative;
+    margin-left: auto;
+    min-width: 220px;
+}
+
+.omni input {
+    width: 100%;
+}
+
+.omni-results {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 4px;
+}
+
+.omni-results .omni-hit {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    text-align: left;
+    background: var(--bg);
+    border: none;
+    border-radius: 0;
+    padding: 0.45rem 0.6rem;
+}
+
+.omni-results .omni-hit:hover {
+    background: var(--bg-hover);
+}
+
+.omni-kind {
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    min-width: 3.2em;
+}

--- a/sports/webui/src/app.rs
+++ b/sports/webui/src/app.rs
@@ -1,8 +1,11 @@
 use dioxus::prelude::*;
 
-use crate::pages::{
-    GameDetail, Games, Home, Leaderboards, Matchup, PlayerDetail, Players, SeasonDetail, Seasons, SqlConsole,
-    TeamDetail, Teams,
+use crate::{
+    components::GlobalSearch,
+    pages::{
+        GameDetail, Games, Home, Leaderboards, Matchup, PlayerDetail, Players, SeasonDetail, Seasons, SqlConsole,
+        TeamDetail, Teams,
+    },
 };
 
 #[derive(Debug, Clone, Routable, PartialEq)]
@@ -72,6 +75,7 @@ fn Navbar() -> Element {
                 }
                 Link { to: Route::SqlConsole {}, active_class: "active", "SQL" }
             }
+            GlobalSearch {}
         }
         main { class: "content", Outlet::<Route> {} }
     }

--- a/sports/webui/src/components/mod.rs
+++ b/sports/webui/src/components/mod.rs
@@ -1,5 +1,7 @@
 pub mod chart;
 mod pagination;
 pub mod replay;
+mod search;
 
 pub use pagination::Pagination;
+pub use search::GlobalSearch;

--- a/sports/webui/src/components/search.rs
+++ b/sports/webui/src/components/search.rs
@@ -1,0 +1,98 @@
+use dioxus::prelude::*;
+
+use crate::{app::Route, dto::TeamRef, server};
+
+/// Navbar omnibox: search players and teams from anywhere. Enter jumps to
+/// the top hit, Escape clears.
+#[component]
+pub fn GlobalSearch() -> Element {
+    let mut q = use_signal(String::new);
+    let teams = use_resource(server::team_options);
+    let players = use_resource(move || {
+        let query = q();
+        async move {
+            if query.trim().len() < 2 {
+                return Ok(Vec::new());
+            }
+            server::search_players(query, 6).await
+        }
+    });
+    let nav = use_navigator();
+
+    let query_now = q.read().trim().to_lowercase();
+    let team_hits: Vec<TeamRef> = if query_now.len() < 2 {
+        Vec::new()
+    } else {
+        match &*teams.read() {
+            Some(Ok(all)) => all
+                .iter()
+                .filter(|t| t.code.to_lowercase().contains(&query_now) || t.name.to_lowercase().contains(&query_now))
+                .take(3)
+                .cloned()
+                .collect(),
+            _ => Vec::new(),
+        }
+    };
+    let player_hits = match &*players.read() {
+        Some(Ok(hits)) => hits.clone(),
+        _ => Vec::new(),
+    };
+    let open = query_now.len() >= 2 && (!team_hits.is_empty() || !player_hits.is_empty());
+
+    let first_route: Option<Route> = team_hits
+        .first()
+        .map(|t| Route::TeamDetail { id: t.id })
+        .or_else(|| player_hits.first().map(|p| Route::PlayerDetail { id: p.id }));
+
+    rsx! {
+        div { class: "omni",
+            input {
+                r#type: "search",
+                placeholder: "Search players & teams…",
+                value: "{q}",
+                oninput: move |e| q.set(e.value()),
+                onkeydown: {
+                    let first_route = first_route.clone();
+                    move |e| match e.key() {
+                        Key::Enter => {
+                            if let Some(route) = first_route.clone() {
+                                q.set(String::new());
+                                nav.push(route);
+                            }
+                        }
+                        Key::Escape => q.set(String::new()),
+                        _ => {}
+                    }
+                },
+            }
+            if open {
+                div { class: "omni-results",
+                    for t in team_hits {
+                        button {
+                            class: "omni-hit",
+                            key: "t{t.id}",
+                            onclick: move |_| {
+                                q.set(String::new());
+                                nav.push(Route::TeamDetail { id: t.id });
+                            },
+                            span { class: "omni-kind", "team" }
+                            "{t.code} · {t.name}"
+                        }
+                    }
+                    for p in player_hits {
+                        button {
+                            class: "omni-hit",
+                            key: "p{p.id}",
+                            onclick: move |_| {
+                                q.set(String::new());
+                                nav.push(Route::PlayerDetail { id: p.id });
+                            },
+                            span { class: "omni-kind", "player" }
+                            "{p.name}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a `GlobalSearch` omnibox component to the navbar, allowing users to search for players and teams from anywhere in the app.

Results appear as a dropdown after at least two characters are typed, showing up to 3 team matches (filtered client-side by code or name) and up to 6 player matches (fetched from the server). Pressing Enter navigates to the top result, and Escape clears the input. Clicking any result also navigates directly to the corresponding team or player detail page.