### PR TITLE
Add postseason filter to batting and pitching leaderboards

### DIFF
--- a/sports/webui/src/dto.rs
+++ b/sports/webui/src/dto.rs
@@ -630,6 +630,7 @@ pub struct SeasonSummary {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BattingLeaderboardReq {
     pub sort: BattingSort,
+    pub postseason: bool,
     pub min_pa: i64,
     pub season: Option<i32>,
     pub limit: u32,
@@ -662,6 +663,7 @@ pub struct BattingLeaderRow {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PitchingLeaderboardReq {
     pub sort: PitchingSort,
+    pub postseason: bool,
     pub min_outs: i64,
     pub season: Option<i32>,
     pub limit: u32,

--- a/sports/webui/src/pages/leaderboards.rs
+++ b/sports/webui/src/pages/leaderboards.rs
@@ -19,6 +19,7 @@ enum Tab {
 pub fn Leaderboards(season: Option<i32>) -> Element {
     let mut tab = use_signal(|| Tab::Batting);
     let mut season_sel = use_signal(|| season);
+    let mut postseason = use_signal(|| false);
     let seasons = use_resource(server::list_seasons);
 
     let season_years: Vec<i32> = match &*seasons.read() {
@@ -46,31 +47,43 @@ pub fn Leaderboards(season: Option<i32>) -> Element {
                     option { value: "{year}", selected: season_sel() == Some(year), "{year}" }
                 }
             }
+            button {
+                class: if postseason() { "" } else { "active" },
+                onclick: move |_| postseason.set(false),
+                "Regular season"
+            }
+            button {
+                class: if postseason() { "active" } else { "" },
+                onclick: move |_| postseason.set(true),
+                "Postseason"
+            }
         }
         if tab() == Tab::Batting {
-            BattingBoard { season: season_sel }
+            BattingBoard { season: season_sel, postseason }
         } else {
-            PitchingBoard { season: season_sel }
+            PitchingBoard { season: season_sel, postseason }
         }
-        div { class: "footnote", "Regular season only. Click a column header to sort." }
+        div { class: "footnote", "Click a column header to sort." }
     }
 }
 
 #[component]
-fn BattingBoard(season: Signal<Option<i32>>) -> Element {
+fn BattingBoard(season: Signal<Option<i32>>, postseason: Signal<bool>) -> Element {
     let mut sort = use_signal(BattingSort::default);
     let mut min_pa = use_signal(|| String::from("50"));
     let mut page = use_signal(|| 0u32);
 
-    // Changing the season invalidates the page position
+    // Changing the season or split invalidates the page position
     use_effect(move || {
         let _ = season();
+        let _ = postseason();
         page.set(0);
     });
 
     let rows = use_resource(move || {
         let req = BattingLeaderboardReq {
             sort: sort(),
+            postseason: postseason(),
             min_pa: min_pa().trim().parse().unwrap_or(0),
             season: season(),
             limit: LIMIT,
@@ -156,14 +169,15 @@ fn BattingBoard(season: Signal<Option<i32>>) -> Element {
 }
 
 #[component]
-fn PitchingBoard(season: Signal<Option<i32>>) -> Element {
+fn PitchingBoard(season: Signal<Option<i32>>, postseason: Signal<bool>) -> Element {
     let mut sort = use_signal(PitchingSort::default);
     let mut min_ip = use_signal(|| String::from("20"));
     let mut page = use_signal(|| 0u32);
 
-    // Changing the season invalidates the page position
+    // Changing the season or split invalidates the page position
     use_effect(move || {
         let _ = season();
+        let _ = postseason();
         page.set(0);
     });
 
@@ -171,6 +185,7 @@ fn PitchingBoard(season: Signal<Option<i32>>) -> Element {
         let min_innings: i64 = min_ip().trim().parse().unwrap_or(0);
         let req = PitchingLeaderboardReq {
             sort: sort(),
+            postseason: postseason(),
             min_outs: min_innings * 3,
             season: season(),
             limit: LIMIT,

--- a/sports/webui/src/pages/season_detail.rs
+++ b/sports/webui/src/pages/season_detail.rs
@@ -21,6 +21,7 @@ pub fn SeasonDetail(year: i32) -> Element {
     let batting = use_resource(move || {
         server::batting_leaderboard(BattingLeaderboardReq {
             sort: BattingSort::Ops,
+            postseason: false,
             min_pa: MIN_PA,
             season: Some(year),
             limit: LEADER_LIMIT,
@@ -30,6 +31,7 @@ pub fn SeasonDetail(year: i32) -> Element {
     let pitching = use_resource(move || {
         server::pitching_leaderboard(PitchingLeaderboardReq {
             sort: PitchingSort::Era,
+            postseason: false,
             min_outs: MIN_IP * 3,
             season: Some(year),
             limit: LEADER_LIMIT,

--- a/sports/webui/src/server/leaderboards.rs
+++ b/sports/webui/src/server/leaderboards.rs
@@ -52,8 +52,8 @@ pub async fn batting_leaderboard(req: BattingLeaderboardReq) -> Result<Page<Batt
     };
 
     let limit = req.limit.clamp(1, 200);
+    let side = if req.postseason { ">" } else { "<=" };
 
-    // Regular season only.
     let sql = format!(
         r"
         WITH regular_end AS ({regular_end})
@@ -75,7 +75,7 @@ pub async fn batting_leaderboard(req: BattingLeaderboardReq) -> Result<Page<Batt
             JOIN players p ON p.id = bl.player_id
             JOIN games g ON g.id = bl.game_id
             JOIN regular_end re ON re.season = EXTRACT(YEAR FROM g.game_date)::int4
-            WHERE g.game_date <= re.end_date
+            WHERE g.game_date {side} re.end_date
               AND ($4::int4 IS NULL OR EXTRACT(YEAR FROM g.game_date)::int4 = $4)
             GROUP BY bl.player_id, p.name
             HAVING COALESCE(SUM(bl.pa), 0) >= $1
@@ -85,7 +85,8 @@ pub async fn batting_leaderboard(req: BattingLeaderboardReq) -> Result<Page<Batt
         ",
         regular_end = super::REGULAR_SEASON_END,
         counts = super::BATTING_COUNT_SQL,
-        rates = super::BATTING_RATE_SQL
+        rates = super::BATTING_RATE_SQL,
+        side = side
     );
 
     let pool = crate::pool().await?;
@@ -156,6 +157,7 @@ pub async fn pitching_leaderboard(req: PitchingLeaderboardReq) -> Result<Page<Pi
         total: i64,
     }
 
+    let side = if req.postseason { ">" } else { "<=" };
     let order = match req.sort {
         PitchingSort::Era => "era ASC NULLS LAST",
         PitchingSort::Whip => "whip ASC NULLS LAST",
@@ -200,7 +202,7 @@ pub async fn pitching_leaderboard(req: PitchingLeaderboardReq) -> Result<Page<Pi
             JOIN players p ON p.id = pl.player_id
             JOIN games g ON g.id = pl.game_id
             JOIN regular_end re ON re.season = EXTRACT(YEAR FROM g.game_date)::int4
-            WHERE g.game_date <= re.end_date
+            WHERE g.game_date {side} re.end_date
               AND ($4::int4 IS NULL OR EXTRACT(YEAR FROM g.game_date)::int4 = $4)
             GROUP BY pl.player_id, p.name
         ) totals
@@ -208,7 +210,8 @@ pub async fn pitching_leaderboard(req: PitchingLeaderboardReq) -> Result<Page<Pi
         ORDER BY {order}
         LIMIT $2 OFFSET $3
         ",
-        regular_end = super::REGULAR_SEASON_END
+        regular_end = super::REGULAR_SEASON_END,
+        side = side
     );
 
     let pool = crate::pool().await?;


### PR DESCRIPTION
Adds a postseason toggle to the batting and pitching leaderboards, allowing users to view stats from either the regular season or postseason. Previously, leaderboards were restricted to regular season games only.

A "Regular season" / "Postseason" button pair is added to the leaderboard page UI. Switching between them resets pagination and re-fetches data filtered to the appropriate game dates. The `postseason` flag is threaded through the `BattingLeaderboardReq` and `PitchingLeaderboardReq` DTOs down to the SQL queries, where the date comparison operator is flipped from `<=` to `>` relative to the regular season end date to select postseason games. The season detail page explicitly passes `postseason: false` to preserve its existing regular-season-only behavior.