### PR TITLE
Add Feats page with no-hitters, cycles, high-K starts, and four-homer games

### DIFF
--- a/sports/webui/assets/main.css
+++ b/sports/webui/assets/main.css
@@ -1086,3 +1086,32 @@ a.h2h-card:hover {
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
     gap: 0 1.25rem;
 }
+
+/* Feats (achievements) page */
+.feat-section {
+  margin-top: 2rem;
+}
+.feat-scroll {
+  max-height: 480px;
+  overflow-y: auto;
+}
+.feat-scroll thead th {
+  position: sticky;
+  top: 0;
+  background: var(--bg-panel);
+  z-index: 1;
+}
+.feat-badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--bg);
+  background: var(--chart-3);
+  white-space: nowrap;
+}
+.feat-badge-combined {
+  background: var(--chart-4);
+}

--- a/sports/webui/src/app.rs
+++ b/sports/webui/src/app.rs
@@ -3,8 +3,8 @@ use dioxus::prelude::*;
 use crate::{
     components::GlobalSearch,
     pages::{
-        GameDetail, Games, Home, Leaderboards, Matchup, PlayerDetail, Players, Records, SeasonDetail, Seasons,
-        SqlConsole, TeamDetail, Teams,
+        Achievements, GameDetail, Games, Home, Leaderboards, Matchup, PlayerDetail, Players, Records, SeasonDetail,
+        Seasons, SqlConsole, TeamDetail, Teams,
     },
 };
 
@@ -36,6 +36,8 @@ pub enum Route {
     Matchup { batter: Option<i32>, pitcher: Option<i32> },
     #[route("/records")]
     Records {},
+    #[route("/feats")]
+    Achievements {},
     #[route("/sql")]
     SqlConsole {},
 }
@@ -76,6 +78,7 @@ fn Navbar() -> Element {
                     "Matchup"
                 }
                 Link { to: Route::Records {}, active_class: "active", "Records" }
+                Link { to: Route::Achievements {}, active_class: "active", "Feats" }
                 Link { to: Route::SqlConsole {}, active_class: "active", "SQL" }
             }
             GlobalSearch {}

--- a/sports/webui/src/dto.rs
+++ b/sports/webui/src/dto.rs
@@ -699,6 +699,38 @@ pub struct SqlResult {
     pub elapsed_ms: u64,
 }
 
+/// A no-hitter thrown by one or more pitchers.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NoHitterRow {
+    pub game_id: i32,
+    pub game_date: NaiveDate,
+    pub team: String,
+    pub opponent: String,
+    pub pitchers: String,
+    pub walks: i64,
+    pub perfect: bool,
+}
+
+/// One player's notable single-game feat, with a pre-formatted stat line.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FeatRow {
+    pub game_id: i32,
+    pub game_date: NaiveDate,
+    pub player_id: i32,
+    pub name: String,
+    pub team: String,
+    pub opponent: String,
+    pub line: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AchievementsDto {
+    pub no_hitters: Vec<NoHitterRow>,
+    pub k_games: Vec<FeatRow>,
+    pub cycles: Vec<FeatRow>,
+    pub hr_games: Vec<FeatRow>,
+}
+
 /// Format a total expressed in outs as baseball innings-pitched notation (e.g. 62 outs -> "20.2").
 pub fn format_ip(outs: i64) -> String {
     format!("{}.{}", outs / 3, outs % 3)

--- a/sports/webui/src/pages/achievements.rs
+++ b/sports/webui/src/pages/achievements.rs
@@ -1,0 +1,131 @@
+use dioxus::prelude::*;
+
+use crate::{app::Route, dto::FeatRow, server};
+
+/// Curated notable-game feats: no-hitters, high-strikeout starts, cycles,
+/// and four-homer games across every scraped season.
+#[component]
+pub fn Achievements() -> Element {
+    let feats = use_resource(server::achievements);
+
+    rsx! {
+        h1 { "Feats" }
+        div { class: "muted",
+            "One-game achievements detected from box scores across every scraped season."
+        }
+        match &*feats.read() {
+            Some(Ok(dto)) => rsx! {
+                NoHitters { rows: dto.no_hitters.clone() }
+                FeatSection {
+                    title: format!("High-strikeout games ({} pitchers with 18+ K)", dto.k_games.len()),
+                    header: "Line",
+                    rows: dto.k_games.clone(),
+                }
+                FeatSection {
+                    title: format!("Four-homer games ({})", dto.hr_games.len()),
+                    header: "Line",
+                    rows: dto.hr_games.clone(),
+                }
+                FeatSection {
+                    title: format!("Cycles ({})", dto.cycles.len()),
+                    header: "Line",
+                    rows: dto.cycles.clone(),
+                }
+            },
+            Some(Err(e)) => rsx! {
+                div { class: "error-box", "Failed to load feats: {e}" }
+            },
+            None => rsx! {
+                div { class: "loading", "Scanning 76 seasons of box scores…" }
+            },
+        }
+    }
+}
+
+#[component]
+fn NoHitters(rows: Vec<crate::dto::NoHitterRow>) -> Element {
+    if rows.is_empty() {
+        return rsx! {};
+    }
+    let count = rows.len();
+    let perfect = rows.iter().filter(|r| r.perfect).count();
+    rsx! {
+        section { class: "feat-section",
+            h2 { "No-hitters ({count}, {perfect} perfect)" }
+            div { class: "table-scroll feat-scroll",
+                table { class: "data-table",
+                    thead {
+                        tr {
+                            th { "Date" }
+                            th { "Pitchers" }
+                            th { "Team" }
+                            th { "Against" }
+                            th { class: "num", "BB" }
+                            th { "" }
+                        }
+                    }
+                    tbody {
+                        for r in rows {
+                            tr { key: "{r.game_id}-{r.team}",
+                                td {
+                                    Link { to: Route::GameDetail { id: r.game_id }, "{r.game_date}" }
+                                }
+                                td { "{r.pitchers}" }
+                                td { "{r.team}" }
+                                td { "{r.opponent}" }
+                                td { class: "num", "{r.walks}" }
+                                td {
+                                    if r.perfect {
+                                        span { class: "feat-badge", "PERFECT GAME" }
+                                    } else if r.pitchers.contains(',') {
+                                        span { class: "feat-badge feat-badge-combined", "COMBINED" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn FeatSection(title: String, header: &'static str, rows: Vec<FeatRow>) -> Element {
+    if rows.is_empty() {
+        return rsx! {};
+    }
+    rsx! {
+        section { class: "feat-section",
+            h2 { "{title}" }
+            div { class: "table-scroll feat-scroll",
+                table { class: "data-table",
+                    thead {
+                        tr {
+                            th { "Date" }
+                            th { "Player" }
+                            th { "Team" }
+                            th { "Against" }
+                            th { "{header}" }
+                        }
+                    }
+                    tbody {
+                        for r in rows {
+                            tr { key: "{r.game_id}-{r.player_id}",
+                                td {
+                                    Link { to: Route::GameDetail { id: r.game_id }, "{r.game_date}" }
+                                }
+                                td {
+                                    Link { to: Route::PlayerDetail { id: r.player_id }, "{r.name}" }
+                                }
+                                td { "{r.team}" }
+                                td { "{r.opponent}" }
+                                td { b { "{r.line}" } }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sports/webui/src/pages/mod.rs
+++ b/sports/webui/src/pages/mod.rs
@@ -1,3 +1,4 @@
+mod achievements;
 mod game_detail;
 mod games;
 mod home;
@@ -12,6 +13,7 @@ mod sql_console;
 mod team_detail;
 mod teams;
 
+pub use achievements::Achievements;
 pub use game_detail::GameDetail;
 pub use games::Games;
 pub use home::Home;

--- a/sports/webui/src/server/achievements.rs
+++ b/sports/webui/src/server/achievements.rs
@@ -1,0 +1,190 @@
+use dioxus::prelude::*;
+
+use crate::dto::{AchievementsDto, FeatRow, NoHitterRow};
+
+/// Curated notable-game feats detectable from box-score sums: no-hitters
+/// (with perfect games flagged), 18+ strikeout starts, cycles, and
+/// four-homer games.
+#[server]
+#[allow(clippy::too_many_lines)]
+pub async fn achievements() -> Result<AchievementsDto, ServerFnError> {
+    #[derive(sqlx::FromRow)]
+    struct NhRow {
+        game_id: i32,
+        game_date: chrono::NaiveDate,
+        team: String,
+        opponent: String,
+        pitchers: String,
+        walks: i64,
+        perfect: bool,
+    }
+
+    #[derive(sqlx::FromRow)]
+    struct PitchFeat {
+        game_id: i32,
+        game_date: chrono::NaiveDate,
+        player_id: i32,
+        name: String,
+        team: String,
+        opponent: String,
+        so: i64,
+        outs: i64,
+    }
+
+    #[derive(sqlx::FromRow)]
+    struct BatFeat {
+        game_id: i32,
+        game_date: chrono::NaiveDate,
+        player_id: i32,
+        name: String,
+        team: String,
+        opponent: String,
+        h: i64,
+        ab: i64,
+        home_runs: i64,
+        rbi: i64,
+    }
+
+    const BAT_FEAT_SELECT: &str = r"
+        SELECT bl.game_id, g.game_date, bl.player_id, p.name, t.code AS team,
+               CASE WHEN bl.team_id = g.home_team_id THEN ta.code ELSE th.code END AS opponent,
+               COALESCE(bl.h, 0)::bigint AS h, COALESCE(bl.ab, 0)::bigint AS ab,
+               bl.home_runs::bigint AS home_runs, COALESCE(bl.rbi, 0)::bigint AS rbi
+        FROM batting_lines bl
+        JOIN games g ON g.id = bl.game_id
+        JOIN players p ON p.id = bl.player_id
+        JOIN teams t ON t.id = bl.team_id
+        JOIN teams th ON th.id = g.home_team_id
+        JOIN teams ta ON ta.id = g.away_team_id
+    ";
+
+    let pool = crate::pool().await?;
+
+    let nh_rows: Vec<NhRow> = sqlx::query_as(sqlx::AssertSqlSafe(
+        r"
+        WITH nh AS (
+            SELECT pl.game_id, pl.team_id,
+                   string_agg(p.name, ', ' ORDER BY pl.pitch_order) AS pitchers,
+                   COALESCE(SUM(pl.bb), 0)::bigint AS walks,
+                   COALESCE(SUM(pl.batters_faced), 0)::bigint AS bf
+            FROM pitching_lines pl
+            JOIN players p ON p.id = pl.player_id
+            GROUP BY pl.game_id, pl.team_id
+            HAVING SUM(pl.h) = 0
+               AND SUM(FLOOR(pl.ip) * 3 + ROUND((pl.ip - FLOOR(pl.ip)) * 10)) >= 27
+        )
+        SELECT nh.game_id, g.game_date, t.code AS team,
+               CASE WHEN nh.team_id = g.home_team_id THEN ta.code ELSE th.code END AS opponent,
+               nh.pitchers, nh.walks,
+               (nh.walks = 0 AND nh.bf = 27 AND NOT EXISTS (
+                   SELECT 1 FROM play_by_play pbp
+                   WHERE pbp.game_id = nh.game_id
+                     AND pbp.batting_team_id <> nh.team_id
+                     AND pbp.runners_before IS NOT NULL
+               )) AS perfect
+        FROM nh
+        JOIN games g ON g.id = nh.game_id
+        JOIN teams t ON t.id = nh.team_id
+        JOIN teams th ON th.id = g.home_team_id
+        JOIN teams ta ON ta.id = g.away_team_id
+        ORDER BY g.game_date DESC
+        "
+        .to_string(),
+    ))
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    let k_rows: Vec<PitchFeat> = sqlx::query_as(sqlx::AssertSqlSafe(
+        r"
+        SELECT pl.game_id, g.game_date, pl.player_id, p.name, t.code AS team,
+               CASE WHEN pl.team_id = g.home_team_id THEN ta.code ELSE th.code END AS opponent,
+               pl.so::bigint AS so,
+               (FLOOR(pl.ip) * 3 + ROUND((pl.ip - FLOOR(pl.ip)) * 10))::bigint AS outs
+        FROM pitching_lines pl
+        JOIN games g ON g.id = pl.game_id
+        JOIN players p ON p.id = pl.player_id
+        JOIN teams t ON t.id = pl.team_id
+        JOIN teams th ON th.id = g.home_team_id
+        JOIN teams ta ON ta.id = g.away_team_id
+        WHERE pl.so >= 18
+        ORDER BY pl.so DESC, g.game_date
+        "
+        .to_string(),
+    ))
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    let cycle_rows: Vec<BatFeat> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        r"{BAT_FEAT_SELECT}
+        WHERE bl.h - bl.doubles - bl.triples - bl.home_runs >= 1
+          AND bl.doubles >= 1 AND bl.triples >= 1 AND bl.home_runs >= 1
+        ORDER BY g.game_date DESC
+        "
+    )))
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    let hr_rows: Vec<BatFeat> = sqlx::query_as(sqlx::AssertSqlSafe(format!(
+        r"{BAT_FEAT_SELECT}
+        WHERE bl.home_runs >= 4
+        ORDER BY g.game_date DESC
+        "
+    )))
+    .fetch_all(pool)
+    .await
+    .map_err(super::db_err)?;
+
+    Ok(AchievementsDto {
+        no_hitters: nh_rows
+            .into_iter()
+            .map(|r| NoHitterRow {
+                game_id: r.game_id,
+                game_date: r.game_date,
+                team: r.team,
+                opponent: r.opponent,
+                pitchers: r.pitchers,
+                walks: r.walks,
+                perfect: r.perfect,
+            })
+            .collect(),
+        k_games: k_rows
+            .into_iter()
+            .map(|r| FeatRow {
+                game_id: r.game_id,
+                game_date: r.game_date,
+                player_id: r.player_id,
+                name: r.name,
+                team: r.team,
+                opponent: r.opponent,
+                line: format!("{} K in {} IP", r.so, crate::dto::format_ip(r.outs)),
+            })
+            .collect(),
+        cycles: cycle_rows
+            .into_iter()
+            .map(|r| FeatRow {
+                line: format!("{}-for-{}, {} RBI", r.h, r.ab, r.rbi),
+                game_id: r.game_id,
+                game_date: r.game_date,
+                player_id: r.player_id,
+                name: r.name,
+                team: r.team,
+                opponent: r.opponent,
+            })
+            .collect(),
+        hr_games: hr_rows
+            .into_iter()
+            .map(|r| FeatRow {
+                line: format!("{} HR, {} RBI ({}-for-{})", r.home_runs, r.rbi, r.h, r.ab),
+                game_id: r.game_id,
+                game_date: r.game_date,
+                player_id: r.player_id,
+                name: r.name,
+                team: r.team,
+                opponent: r.opponent,
+            })
+            .collect(),
+    })
+}

--- a/sports/webui/src/server/mod.rs
+++ b/sports/webui/src/server/mod.rs
@@ -1,3 +1,4 @@
+mod achievements;
 mod dashboard;
 mod games;
 mod leaderboards;
@@ -8,6 +9,7 @@ mod seasons;
 mod sql_console;
 mod teams;
 
+pub use achievements::*;
 pub use dashboard::*;
 pub use games::*;
 pub use leaderboards::*;


### PR DESCRIPTION
## Add "Feats" page for notable single-game achievements

Introduces a new **Feats** page (`/feats`) that surfaces curated one-game achievements detected from box scores across every scraped season:

- **No-hitters** — including combined no-hitters and perfect games, with walk count and a badge distinguishing perfect games from combined efforts
- **High-strikeout starts** — pitchers with 18 or more strikeouts in a single game, displayed with K total and innings pitched
- **Four-homer games** — batters who hit four or more home runs in a game, with HR, RBI, and hit line
- **Cycles** — batters who hit for the cycle, with their full hit and RBI line

Each table links game dates to the game detail page and player names to the player detail page. Tables use a sticky header with a capped scroll height to keep long lists manageable.

On the backend, four SQL queries detect each feat type from `pitching_lines`, `batting_lines`, and `games`. Perfect games are identified by cross-referencing `play_by_play` to confirm no baserunners reached. The page is added to the navbar between Records and SQL.