### PR TITLE
[christmas] move compose.yaml into this repo and auto-deploy on push

### DIFF
--- a/.github/workflows/deploy-christmas.yml
+++ b/.github/workflows/deploy-christmas.yml
@@ -11,11 +11,6 @@ on:
       - "Dockerfile"
       - ".github/workflows/deploy-christmas.yml"
   workflow_dispatch:
-    inputs:
-      deploy:
-        description: "Also restart the service on the droplet"
-        type: boolean
-        default: false
 
 # A second push to main should not race the first one onto the droplet.
 concurrency:
@@ -39,6 +34,24 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+
+      # ECR does not create repositories on push, so without this the first run
+      # fails with "The repository with name '...' does not exist". Idempotent.
+      - name: Ensure the ECR repository exists
+        run: |
+          if aws ecr describe-repositories --repository-names "$ECR_REPOSITORY" >/dev/null 2>&1; then
+            echo "ECR repository '$ECR_REPOSITORY' already exists"
+            exit 0
+          fi
+
+          echo "Creating ECR repository '$ECR_REPOSITORY'"
+          if ! aws ecr create-repository --repository-name "$ECR_REPOSITORY" >/dev/null; then
+            echo "::error::Could not create the ECR repository. If this is an" \
+                 "AccessDenied, the deploy user needs ecr:CreateRepository — or" \
+                 "create it once by hand:" \
+                 "aws ecr create-repository --repository-name $ECR_REPOSITORY"
+            exit 1
+          fi
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -76,15 +89,15 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # The compose file and Caddyfile live in the arenabuddy repo, so this only
-  # restarts an already-declared service. See christmas/DEPLOY.md for the
-  # one-time setup that has to land there first.
+  # christmas/compose.yaml lives in this repo, so this job owns the whole
+  # service. The only thing still on the arenabuddy side is the Caddy site
+  # block — see christmas/DEPLOY.md for the one-time setup, which has to be in
+  # place before the first run of this job.
   deploy:
-    if: github.event_name == 'workflow_dispatch' && inputs.deploy
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Restart christmas on the droplet
+      - name: Deploy to the droplet
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
@@ -98,8 +111,13 @@ jobs:
             aws ecr get-login-password --region "$AWS_REGION" \
               | docker login --username AWS --password-stdin "$ECR_REGISTRY"
 
-            cd /root/code/arenabuddy/server
+            cd /root/code/monorepo
+            git pull --ff-only origin main
+
+            cd christmas
+            # Exported here so it wins over any CHRISTMAS_IMAGE in /root/.env,
+            # pinning this deploy to the image built by this run.
             export CHRISTMAS_IMAGE="$ECR_REGISTRY/christmas:${{ github.sha }}"
-            docker compose pull christmas
-            docker compose up -d christmas
+            docker compose --env-file /root/.env pull
+            docker compose --env-file /root/.env up -d
             docker image prune -f

--- a/christmas/DEPLOY.md
+++ b/christmas/DEPLOY.md
@@ -1,12 +1,17 @@
 # Deploying christmas
 
-Target: `https://christmas.grantazure.com`, running as a service inside the
-existing arenabuddy compose stack on the DigitalOcean droplet, reusing its Caddy,
-TLS certificates, and PostgreSQL.
+Target: `https://christmas.grantazure.com`, running from its own compose project
+in this repo (`christmas/compose.yaml`), joined to the Docker network the
+arenabuddy stack already runs on so it can reuse that Caddy, its TLS
+certificates, and its PostgreSQL.
+
+Being a **separate compose project** is deliberate. arenabuddy deploys with
+`docker compose up -d --remove-orphans`; a service defined in *its* compose file
+would be torn down or silently reverted to `:latest` by that. Owning our own
+project keeps the two deploys independent.
 
 The app is **fullstack** — a Rust server process plus a database — unlike
-arenabuddy's `web`, which is static files behind Caddy. So it needs its own
-service entry, not a copy of that pattern.
+arenabuddy's `web`, which is static files behind Caddy.
 
 ## What this repo does
 
@@ -14,25 +19,29 @@ service entry, not a copy of that pattern.
 `Dockerfile` (`APP_NAME=christmas`) and pushes it to ECR as `christmas:latest`
 and `christmas:<sha>` on every push to `main` that touches the crate.
 
-It does **not** deploy on push. The compose file and Caddyfile live in the
-arenabuddy repo, so the one-time setup below has to land there first; after that,
-run the workflow manually with **Also restart the service on the droplet**
-checked, or just `docker compose up -d christmas` on the box.
+It then SSHes to the droplet and rolls the service over, the same way arenabuddy
+does. **The one-time setup below must be in place before the first run**, or the
+deploy job will fail on a missing network or database.
+
+To deploy by hand:
+
+```bash
+cd /root/code/monorepo && git pull --ff-only origin main
+cd christmas
+docker compose --env-file /root/.env pull
+docker compose --env-file /root/.env up -d
+```
 
 Required repo secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`,
 and — for the optional deploy job — `DEPLOY_HOST`, `DEPLOY_SSH_KEY`.
 
 ## One-time setup
 
-### 1. ECR repository
+The ECR repository is not on this list: the workflow creates `christmas` on its
+first run if it does not already exist, because ECR does not create repositories
+on push and the resulting error is unhelpful.
 
-ECR does not create repositories on push.
-
-```bash
-aws ecr create-repository --repository-name christmas --region "$AWS_REGION"
-```
-
-### 2. Database
+### 1. Database
 
 Reuse the existing PostgreSQL 17 container rather than running a second one:
 
@@ -44,19 +53,55 @@ docker compose exec postgres psql -U arenabuddy -d postgres \
 
 Migrations run automatically the first time the app touches the database.
 
+### 2. The shared network
+
+`compose.yaml` joins an existing external network. Compose names a project's
+default network `<project>_default`, and arenabuddy's project is the directory
+its compose file sits in — so it is most likely `server_default`. Confirm:
+
+```bash
+docker network ls
+docker network inspect server_default --format '{{range .Containers}}{{.Name}} {{end}}'
+```
+
+`server_default` is confirmed correct. If that ever changes, set
+`CHRISTMAS_NETWORK` in `/root/.env`. Getting it wrong fails loudly — *"network
+... declared as external, but could not be found"* — rather than starting
+something unreachable.
+
 ### 3. Droplet environment
 
-Add to `/root/.env`:
+The monorepo must be checked out at `/root/code/monorepo` — the deploy job
+`git pull`s there and runs compose from `christmas/`.
+
+Everything else is environment. `/root/.env` is read twice: `source`d by the
+deploy script, and passed to compose as `--env-file`.
+
+**Already present for arenabuddy** — nothing to do, just don't remove them:
+
+| Variable | Used by | Why |
+| --- | --- | --- |
+| `AWS_REGION` | deploy script | Builds the ECR registry hostname, and `aws ecr get-login-password` |
+| `AWS_ACCESS_KEY_ID` | `aws` CLI on the droplet | `aws sts get-caller-identity` discovers the account id |
+| `AWS_SECRET_ACCESS_KEY` | `aws` CLI on the droplet | as above |
+
+**New, add these:**
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `CHRISTMAS_DB_PASSWORD` | **yes** | — | Password for the `christmas` database role. Compose refuses to start without it. |
+| `CHRISTMAS_ADMIN_PASSWORD` | strongly | *(empty)* | Manager password. Empty means nobody can reach Manage. |
+| `CHRISTMAS_VIEW_PASSWORD` | strongly | *(empty)* | Family password. **If this and the admin one are both empty the site is wide open**, and the container logs a warning saying so. |
+| `CHRISTMAS_IMAGE` | no | `christmas:latest` | The deploy job exports the exact `:<sha>` tag, which wins. Worth setting to the ECR `:latest` path so a manual `docker compose up` still finds a real image. |
+| `CHRISTMAS_NETWORK` | no | `server_default` | The arenabuddy network. The default is correct today. |
+| `CHRISTMAS_DB_HOST` | no | `postgres` | PostgreSQL's service name on the shared network. |
 
 ```sh
-CHRISTMAS_DB_PASSWORD=<the password above>
-# Must be defined here, not only at deploy time — see the gotcha below.
-CHRISTMAS_IMAGE=<account>.dkr.ecr.<region>.amazonaws.com/christmas:latest
-
-# Shared passwords. If BOTH are unset the site is completely open, and the
-# container logs a warning saying so at boot.
+# --- christmas ---
+CHRISTMAS_DB_PASSWORD=<the password from step 1>
 CHRISTMAS_VIEW_PASSWORD=<what the family gets told>
 CHRISTMAS_ADMIN_PASSWORD=<only you>
+CHRISTMAS_IMAGE=<account>.dkr.ecr.<region>.amazonaws.com/christmas:latest
 ```
 
 ### 4. DNS
@@ -66,36 +111,25 @@ is a **different zone** from `arenabuddy.io`, so it is a new zone to configure,
 not just a new record. Caddy issues the certificate automatically on first
 request, into the `caddy_data` volume that already exists.
 
-### 5. Changes in the arenabuddy repo
+### 5. The one change in the arenabuddy repo
 
-`server/docker-compose.yml` — add alongside `web`:
-
-```yaml
-  christmas:
-    image: ${CHRISTMAS_IMAGE:-christmas:latest}
-    restart: unless-stopped
-    depends_on:
-      postgres:
-        condition: service_healthy
-    environment:
-      CHRISTMAS_DATABASE_URL: postgres://christmas:${CHRISTMAS_DB_PASSWORD}@postgres/christmas
-      CHRISTMAS_VIEW_PASSWORD: ${CHRISTMAS_VIEW_PASSWORD}
-      CHRISTMAS_ADMIN_PASSWORD: ${CHRISTMAS_ADMIN_PASSWORD}
-      IP: 0.0.0.0
-      PORT: "8080"
-    expose:
-      - "8080"
-```
-
-Add `christmas` to the `caddy` service's `depends_on`.
-
-`server/Caddyfile` — add a site block:
+Caddy lives over there and owns ports 80/443, so it needs to learn the hostname.
+Add to `server/Caddyfile`:
 
 ```
 christmas.grantazure.com {
 	reverse_proxy christmas:8080
 }
 ```
+
+That is the *only* arenabuddy-side change — no compose edit, no `depends_on`.
+`christmas` resolves because both projects share the network and the service
+declares that name as an explicit network alias.
+
+### GitHub repository secrets
+
+Already configured, listed here for completeness: `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `DEPLOY_HOST`, `DEPLOY_SSH_KEY`.
 
 ## Passwords
 
@@ -112,7 +146,7 @@ migrate, and re-entering a password once a deploy is not a burden here.
 Rotating a password is a compose restart with the new value; every existing
 session dies with the old process anyway.
 
-## Three things that will bite otherwise
+## Four things that will bite otherwise
 
 1. **The Caddyfile is a bind mount.** Editing it does not reload the running
    Caddy — `docker compose up -d` won't restart a container whose compose
@@ -121,12 +155,18 @@ session dies with the old process anyway.
    docker compose exec caddy caddy reload --config /etc/caddy/Caddyfile
    ```
 
-2. **arenabuddy's own deploy runs `docker compose up -d --remove-orphans`.** If
-   `CHRISTMAS_IMAGE` isn't set in that shell, christmas gets recreated from the
-   compose default and silently reverts. Defining it in `/root/.env` (step 3) is
-   what prevents this — not just exporting it at deploy time.
+2. **Compose only substitutes variables it can see.** `source /root/.env` sets
+   shell variables, not environment ones, so the deploy passes `--env-file
+   /root/.env` explicitly. Running `docker compose up -d` in that directory
+   without it will fail on the missing database password — which is the intended
+   failure, not a bug.
 
-3. **The server binary is named `server`, not `christmas`.** `dx bundle` emits
+3. **`depends_on` cannot cross compose projects**, so christmas may start before
+   PostgreSQL is ready. That is survivable by design: the pool connects lazily on
+   first use and only caches a *successful* connection, so once the database
+   comes up the next request succeeds without a restart.
+
+4. **The server binary is named `server`, not `christmas`.** `dx bundle` emits
    `target/dx/<app>/release/web/{server,public}`. The root `Dockerfile` accounts
    for this; don't "fix" its `CMD` back to `${APP_NAME}`.
 
@@ -135,7 +175,8 @@ session dies with the old process anyway.
 ```bash
 # 303 to /login when signed out — a 200 here means auth is not configured
 curl -sI https://christmas.grantazure.com | head -1
-docker compose logs christmas | tail -20   # "database ready", "password protection enabled"
+cd /root/code/monorepo/christmas
+docker compose --env-file /root/.env logs | tail -20   # "database ready", "password protection enabled"
 ```
 
 If the logs say *"the site is completely open"*, the passwords did not reach the
@@ -152,7 +193,9 @@ connecting lazily.
 Once, to load the family:
 
 ```bash
-docker compose run --rm christmas /usr/local/app/server --seed /usr/local/app/seed/family.json
+cd /root/code/monorepo/christmas
+docker compose --env-file /root/.env run --rm \
+  christmas /usr/local/app/server --seed /usr/local/app/seed/family.json
 ```
 
 Seeding is idempotent, so re-running is safe. Alternatively add the pools and

--- a/christmas/compose.yaml
+++ b/christmas/compose.yaml
@@ -1,0 +1,48 @@
+# Christmas gift exchange.
+#
+# Its own compose project, joined to the network arenabuddy's stack already
+# runs on so that Caddy can reach it and it can reach PostgreSQL. Being a
+# separate project matters: arenabuddy deploys with `--remove-orphans`, which
+# would otherwise tear this service down or silently revert its image.
+#
+#   cd /root/code/monorepo/christmas
+#   docker compose --env-file /root/.env up -d
+#
+# Variables come from /root/.env. See DEPLOY.md.
+name: christmas
+
+services:
+  christmas:
+    image: ${CHRISTMAS_IMAGE:-christmas:latest}
+    restart: unless-stopped
+    environment:
+      # Reuses the PostgreSQL already running in the arenabuddy stack, reachable
+      # by service name across the shared network.
+      CHRISTMAS_DATABASE_URL: postgres://christmas:${CHRISTMAS_DB_PASSWORD:?set CHRISTMAS_DB_PASSWORD in /root/.env}@${CHRISTMAS_DB_HOST:-postgres}:5432/christmas
+      # Unset means the site is wide open, and the container says so at boot.
+      CHRISTMAS_VIEW_PASSWORD: ${CHRISTMAS_VIEW_PASSWORD:-}
+      CHRISTMAS_ADMIN_PASSWORD: ${CHRISTMAS_ADMIN_PASSWORD:-}
+      IP: 0.0.0.0
+      PORT: "8080"
+    expose:
+      - "8080"
+    networks:
+      shared:
+        aliases:
+          # What Caddy proxies to. Pinned rather than relying on the service
+          # name, so renaming the service can't quietly break routing.
+          - christmas
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+networks:
+  shared:
+    external: true
+    # Compose names the default network <project>_default, and arenabuddy's
+    # project is the directory its compose file sits in (`server`). Confirm with
+    # `docker network ls` before the first deploy; a wrong name fails loudly with
+    # "network ... declared as external, but could not be found".
+    name: ${CHRISTMAS_NETWORK:-server_default}


### PR DESCRIPTION
The christmas service is promoted from a guest entry in the arenabuddy compose file to its own independent compose project living in `christmas/compose.yaml`. This keeps the two deploys fully separate: arenabuddy runs `--remove-orphans`, which would otherwise tear down or silently revert the christmas service on every arenabuddy deploy.

The deploy workflow now runs unconditionally on every qualifying push rather than requiring a manual trigger with a checkbox. It SSHes to the droplet, pulls the latest monorepo commit, and brings the service up using the exact image SHA built by that run, so the pinned tag always wins over any `CHRISTMAS_IMAGE` already set in `/root/.env`. The workflow also auto-creates the ECR repository on first run if it does not exist, with a clear error message if permissions are missing, removing that as a manual prerequisite.

The only remaining arenabuddy-side change is a single Caddy site block. The compose service entry, `depends_on`, and the `CHRISTMAS_IMAGE`-in-the-wrong-shell gotcha are all gone. The service joins the existing `server_default` network via an explicit alias so Caddy can reach it by name regardless of how the service is named inside the project, and the network name is overridable via `CHRISTMAS_NETWORK` in `/root/.env`.

`DEPLOY.md` is updated throughout to match: the ECR creation step is removed from the one-time checklist, the network setup is documented with confirmation commands, the environment variable table is expanded to cover every variable compose now reads, and the gotchas section is revised to reflect the new project boundary and `--env-file` requirement.