### PR TITLE
[christmas] Add backfill UI and server function for recording past draws

### DIFF
--- a/christmas/README.md
+++ b/christmas/README.md
@@ -39,6 +39,23 @@ Draws are deterministic: the same seed and inputs always produce the same result
 The search is bounded by a step budget rather than a wall clock, precisely so
 that stays true regardless of machine load.
 
+## Backfilling a past year
+
+"No repeat receivers" can only avoid what it can see, so a pool whose earlier
+years happened on paper has nothing to avoid. **Manage → Backfill a past year**
+takes who gave to whom in an earlier year and records it as an ordinary
+exchange, which is what makes it count: the same queries read it, so the next
+draw avoids those pairings and skips the letter that year used.
+
+A backfill may be incomplete — leave anyone you cannot remember blank — but it
+cannot contradict itself: nobody gives to themselves, gives twice, or receives
+from two people. `config` and `seed` are left empty rather than invented, since
+nobody knows what rules an old draw ran under, and the pool page's "How it was
+drawn" line is omitted for those years instead of claiming something untrue.
+
+Backfilling uses the same revision counter as a draw, so it never overwrites an
+existing year — recording 2019 twice leaves two revisions, the newer one live.
+
 ## Running it
 
 Needs a PostgreSQL. The workspace's `docker-local-monitoring/docker-compose.yml`

--- a/christmas/assets/main.css
+++ b/christmas/assets/main.css
@@ -964,6 +964,46 @@ button.danger:hover:not(:disabled) {
     text-decoration: line-through;
 }
 
+/* Backfilling a past year: one row per giver, laid out in columns so a
+   fourteen-person pool doesn't become a fourteen-screen form. */
+.backfill-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+    gap: 0.45rem 1.25rem;
+}
+
+.backfill-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.backfill-row .giver {
+    flex: 1 1 0;
+    min-width: 0;
+    font-size: 0.9rem;
+    /* Long names truncate rather than shoving the select out of line. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.backfill-row .arrow {
+    color: var(--brass);
+    flex: none;
+}
+
+.backfill-row select {
+    flex: 1.3 1 0;
+    font-size: 0.88rem;
+}
+
+/* The receiver someone else is already down for. */
+.backfill-row select.clashing {
+    border-color: var(--cranberry);
+    color: var(--cranberry-lit);
+}
+
 /* Toggles in the draw form */
 .toggle-row {
     display: flex;

--- a/christmas/src/components/backfill.rs
+++ b/christmas/src/components/backfill.rs
@@ -1,0 +1,271 @@
+//! Entering a draw that happened before the app existed.
+//!
+//! The reason to bother: "no repeat receivers" can only avoid what it can see,
+//! so a pool with no recorded history has nothing to avoid. Typing last year's
+//! receivers in once gives this year's draw something to work against.
+
+use std::collections::BTreeMap;
+
+use dioxus::prelude::*;
+
+use crate::{
+    model::{Exchange, Pairing, Participant, Pool},
+    server,
+};
+
+/// Hand-entered history for one pool and year.
+///
+/// Everything is passed in rather than fetched here: a `use_resource` whose only
+/// input is a component prop registers no reactive dependency, so it would never
+/// re-run once the lists loaded — the same trap documented in `letters.rs`.
+#[component]
+pub fn BackfillSection(
+    pools: Vec<Pool>,
+    participants: Vec<Participant>,
+    memberships: Vec<(i32, i32)>,
+    exchanges: Vec<Exchange>,
+    year: i32,
+    on_change: EventHandler<()>,
+) -> Element {
+    let first = pools.first().map(|p| p.id);
+    let mut chosen_pool = use_signal(|| None::<i32>);
+    // Backfilling is almost always about the year just gone.
+    let mut back_year = use_signal(|| year - 1);
+    let mut letter = use_signal(|| None::<char>);
+
+    // Giver name → receiver name. Sorted, so the summary reads in a stable order.
+    let mut picks = use_signal(BTreeMap::<String, String>::new);
+
+    let mut saving = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
+    let mut saved = use_signal(|| None::<Exchange>);
+
+    // Derived, not synced through an effect — see the note in `letters.rs`.
+    let pool_id = move || chosen_pool().or(first);
+
+    let members: Vec<String> = participants
+        .iter()
+        .filter(|p| {
+            memberships
+                .iter()
+                .any(|(pool, participant)| Some(*pool) == pool_id() && *participant == p.id)
+        })
+        .map(|p| p.name.clone())
+        .collect();
+
+    // What is already on the record for this pool and year, if anything. Newest
+    // revision first, so this is the live one.
+    let existing = exchanges
+        .iter()
+        .find(|e| Some(e.pool_id) == pool_id() && e.year == back_year())
+        .cloned();
+
+    // Two givers cannot share a receiver. Flagged as it is typed, because
+    // finding out on save which of fourteen selects is wrong is miserable.
+    let clashes: Vec<String> = {
+        let chosen = picks.read();
+        let mut counts = BTreeMap::<&str, usize>::new();
+        for receiver in chosen.values() {
+            *counts.entry(receiver.as_str()).or_default() += 1;
+        }
+        counts
+            .into_iter()
+            .filter(|(_, n)| *n > 1)
+            .map(|(name, _)| name.to_string())
+            .collect()
+    };
+    let filled = picks.read().len();
+    let ready = filled > 0 && clashes.is_empty();
+
+    let mut load_existing = {
+        let existing = existing.clone();
+        move |()| {
+            let Some(draw) = existing.as_ref() else { return };
+            let mut loaded = BTreeMap::new();
+            for pair in &draw.pairings {
+                loaded.insert(pair.giver.clone(), pair.receiver.clone());
+            }
+            picks.set(loaded);
+            letter.set(draw.letter);
+            saved.set(None);
+            error.set(None);
+        }
+    };
+
+    let save = move |_| {
+        let Some(id) = pool_id() else {
+            error.set(Some("Pick a pool".to_string()));
+            return;
+        };
+        let pairings: Vec<Pairing> = picks
+            .read()
+            .iter()
+            .map(|(giver, receiver)| Pairing {
+                giver: giver.clone(),
+                receiver: receiver.clone(),
+            })
+            .collect();
+        let y = back_year();
+        let l = letter();
+
+        saving.set(true);
+        error.set(None);
+        spawn(async move {
+            match server::record_past_draw(id, y, pairings, l).await {
+                Ok(exchange) => {
+                    saved.set(Some(exchange));
+                    error.set(None);
+                    picks.set(BTreeMap::new());
+                    letter.set(None);
+                    on_change.call(());
+                }
+                Err(e) => {
+                    saved.set(None);
+                    error.set(Some(e.to_string()));
+                }
+            }
+            saving.set(false);
+        });
+    };
+
+    rsx! {
+        div { class: "panel",
+            h3 { "Backfill a past year" }
+            p { class: "muted", style: "font-size: 0.85rem; margin-top: -0.5rem",
+                "Type in who gave to whom in an earlier year. Once it's on the record, \"no repeat receivers\" can see it and its letter won't be drawn again. Leave anyone you can't remember blank."
+            }
+
+            if let Some(e) = error() {
+                div { class: "error-box", "{e}" }
+            }
+
+            div { class: "field-row",
+                label { "Pool" }
+                select {
+                    value: pool_id().map_or_else(String::new, |v| v.to_string()),
+                    onchange: move |e| {
+                        chosen_pool.set(e.value().parse().ok());
+                        // The old pool's names mean nothing in the new one.
+                        picks.set(BTreeMap::new());
+                        saved.set(None);
+                    },
+                    for pool in pools.iter() {
+                        option { key: "{pool.id}", value: "{pool.id}", "{pool.name}" }
+                    }
+                }
+                label { "Year" }
+                input {
+                    r#type: "number",
+                    style: "width: 6.5rem",
+                    value: "{back_year}",
+                    oninput: move |e| {
+                        if let Ok(v) = e.value().parse() {
+                            back_year.set(v);
+                            saved.set(None);
+                        }
+                    },
+                }
+                label { "Letter" }
+                select {
+                    style: "width: 5rem",
+                    value: letter().map_or_else(String::new, |c| c.to_string()),
+                    onchange: move |e| letter.set(e.value().chars().next()),
+                    option { value: "", "—" }
+                    for c in 'A'..='Z' {
+                        option { key: "{c}", value: "{c}", "{c}" }
+                    }
+                }
+            }
+
+            if let Some(draw) = existing.as_ref() {
+                div { class: "notice",
+                    "{back_year} is already recorded for this pool "
+                    if draw.pairings.is_empty() {
+                        "with no pairings"
+                    } else {
+                        "with {draw.pairings.len()} pairings"
+                    }
+                    ". Saving records a new revision rather than replacing it. "
+                    button {
+                        class: "linklike",
+                        style: "text-transform: none; letter-spacing: 0",
+                        onclick: move |_| load_existing(()),
+                        "Load it to edit"
+                    }
+                }
+            }
+
+            if members.is_empty() {
+                p { class: "muted", "This pool has no members yet — add people before backfilling." }
+            } else {
+                div { class: "backfill-grid",
+                    for giver in members.iter() {
+                        {
+                            let giver = giver.clone();
+                            let chosen = picks.read().get(&giver).cloned().unwrap_or_default();
+                            let clashing = !chosen.is_empty() && clashes.contains(&chosen);
+                            let others = members.clone();
+                            let key = giver.clone();
+                            rsx! {
+                                div { key: "{key}", class: "backfill-row",
+                                    span { class: "giver", "{giver}" }
+                                    span { class: "arrow", "→" }
+                                    select {
+                                        class: if clashing { "clashing" } else { "" },
+                                        value: "{chosen}",
+                                        onchange: move |e| {
+                                            let picked = e.value();
+                                            if picked.is_empty() {
+                                                picks.write().remove(&giver);
+                                            } else {
+                                                picks.write().insert(giver.clone(), picked);
+                                            }
+                                            saved.set(None);
+                                        },
+                                        option { value: "", "—" }
+                                        for other in others.iter().filter(|o| **o != key) {
+                                            option { key: "{other}", value: "{other}", "{other}" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if !clashes.is_empty() {
+                    div { class: "error-box", style: "margin-top: 1rem",
+                        "Two people are down as giving to "
+                        {clashes.join(", ")}
+                        ". Everyone receives from exactly one person."
+                    }
+                }
+
+                div { class: "field-row", style: "margin-top: 1rem",
+                    button { disabled: saving() || !ready, onclick: save,
+                        if saving() { "Saving…" } else { "Record {back_year}" }
+                    }
+                    span { class: "muted", style: "font-size: 0.85rem",
+                        if filled == 0 {
+                            "Nothing filled in yet."
+                        } else if filled == members.len() {
+                            "All {filled} filled in."
+                        } else {
+                            "{filled} of {members.len()} filled in — the rest will be left out."
+                        }
+                    }
+                }
+            }
+
+            if let Some(exchange) = saved() {
+                div { class: "notice", style: "margin-top: 1rem",
+                    "Recorded {exchange.pairings.len()} pairings for {exchange.year}"
+                    if let Some(letter) = exchange.letter {
+                        ", letter {letter}"
+                    }
+                    " as revision {exchange.revision}."
+                }
+            }
+        }
+    }
+}

--- a/christmas/src/components/mod.rs
+++ b/christmas/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod backfill;
 mod cycle_graph;
 mod decor;
 mod draw_form;
@@ -6,6 +7,7 @@ mod participants;
 mod pools;
 mod relationships;
 
+pub use backfill::BackfillSection;
 pub use cycle_graph::{CycleBoard, RevealRing};
 pub use decor::{Snowfall, StringLights};
 pub use draw_form::DrawSection;

--- a/christmas/src/pages/admin.rs
+++ b/christmas/src/pages/admin.rs
@@ -2,7 +2,9 @@ use dioxus::prelude::*;
 
 use super::current_year;
 use crate::{
-    components::{DrawSection, LettersSection, ParticipantsSection, PoolsSection, RelationshipsSection},
+    components::{
+        BackfillSection, DrawSection, LettersSection, ParticipantsSection, PoolsSection, RelationshipsSection,
+    },
     server,
 };
 
@@ -80,6 +82,15 @@ pub fn Admin() -> Element {
 
         DrawSection {
             pools: pool_list.clone(),
+            exchanges: exchange_list.clone(),
+            year: current_year(),
+            on_change: reload_all,
+        }
+
+        BackfillSection {
+            pools: pool_list.clone(),
+            participants: participant_list.clone(),
+            memberships: membership_list.clone(),
             exchanges: exchange_list,
             year: current_year(),
             on_change: reload_all,

--- a/christmas/src/server/draw.rs
+++ b/christmas/src/server/draw.rs
@@ -379,6 +379,158 @@ pub async fn run_draw(
     })
 }
 
+/// Years a hand-entered draw is allowed to claim. Wide enough for any real
+/// family history, narrow enough to catch a mistyped year.
+const PLAUSIBLE_YEARS: std::ops::RangeInclusive<i32> = 1900..=2200;
+
+/// Checks that a hand-entered draw is shaped like a draw.
+///
+/// A recorded draw is a partial permutation: each person gives once, receives
+/// once, and never to themselves. Leaving someone out is allowed — old paper
+/// records are often incomplete — but contradicting yourself is not.
+///
+/// Kept out of the server function so the rules can be tested without a
+/// database, and returns the offending name so the message is actionable.
+pub(crate) fn validate_backfill(pairings: &[crate::model::Pairing]) -> Result<(), String> {
+    use std::collections::HashSet;
+
+    if pairings.is_empty() {
+        return Err("Fill in at least one giver before saving".to_string());
+    }
+
+    let mut givers = HashSet::new();
+    let mut receivers = HashSet::new();
+
+    for pair in pairings {
+        let (giver, receiver) = (pair.giver.trim(), pair.receiver.trim());
+
+        if giver.is_empty() || receiver.is_empty() {
+            return Err("Every entry needs both a giver and a receiver".to_string());
+        }
+        if giver == receiver {
+            return Err(format!("{giver} cannot give to themselves"));
+        }
+        if !givers.insert(giver) {
+            return Err(format!("{giver} appears twice as a giver"));
+        }
+        if !receivers.insert(receiver) {
+            return Err(format!("Two people are down as giving to {receiver}"));
+        }
+    }
+
+    Ok(())
+}
+
+/// Everyone named in a draw, deduplicated and ordered, for the row's snapshot.
+///
+/// Taken from the pairings rather than the pool's current membership: whoever
+/// took part in 2019 is a fact about 2019, not about who is in the pool now.
+pub(crate) fn backfill_participants(pairings: &[crate::model::Pairing]) -> Vec<String> {
+    let mut names: Vec<String> = pairings
+        .iter()
+        .flat_map(|p| [p.giver.trim().to_string(), p.receiver.trim().to_string()])
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Records a draw that happened outside the app — an earlier year still on paper.
+///
+/// Goes in through the same revision counter as [`run_draw`], so a backfill
+/// never overwrites anything, and comes back out of the same queries. That last
+/// part is the point: once a past year is on the record, "no repeat receivers"
+/// can see it, and its letter is off the table for future draws.
+///
+/// `config` and `seed` are deliberately left at their defaults. We do not know
+/// what rules an old draw ran under, and inventing them would make the pool
+/// page's "How it was drawn" line say something untrue.
+#[server]
+pub async fn record_past_draw(
+    pool_id: i32,
+    year: i32,
+    pairings: Vec<crate::model::Pairing>,
+    letter: Option<char>,
+) -> Result<Exchange, ServerFnError> {
+    use sqlx::types::Json;
+
+    use crate::model::Pairing;
+
+    if !PLAUSIBLE_YEARS.contains(&year) {
+        return Err(ServerFnError::new(format!(
+            "{year} doesn't look like a year — expected {} to {}",
+            PLAUSIBLE_YEARS.start(),
+            PLAUSIBLE_YEARS.end()
+        )));
+    }
+
+    validate_backfill(&pairings).map_err(ServerFnError::new)?;
+
+    // Uppercased here rather than trusted: the column's CHECK only accepts
+    // `[A-Z]`, and a constraint violation is a worse message than this one.
+    let letter = match letter {
+        Some(c) if c.is_ascii_alphabetic() => Some(c.to_ascii_uppercase()),
+        Some(c) => return Err(ServerFnError::new(format!("'{c}' is not a letter"))),
+        None => None,
+    };
+
+    let participants = backfill_participants(&pairings);
+    let pairings: Vec<Pairing> = pairings
+        .into_iter()
+        .map(|p| Pairing {
+            giver: p.giver.trim().to_string(),
+            receiver: p.receiver.trim().to_string(),
+        })
+        .collect();
+
+    let db = crate::pool().await?;
+
+    let row: (i32, i32) = sqlx::query_as(
+        r"INSERT INTO exchange (pool_id, year, revision, letter, participants, exclusions, pairings)
+          VALUES ($1, $2,
+                  (SELECT COALESCE(MAX(revision), 0) + 1 FROM exchange WHERE pool_id = $1 AND year = $2),
+                  $3, $4, '[]'::jsonb, $5)
+          RETURNING id, revision",
+    )
+    .bind(pool_id)
+    .bind(year)
+    .bind(letter.map(|c| c.to_string()))
+    .bind(Json(&participants))
+    .bind(Json(&pairings))
+    .fetch_one(db)
+    .await
+    .map_err(super::db_err)?;
+
+    let pool_row: PoolNameRow = sqlx::query_as("SELECT name, slug FROM pool WHERE id = $1")
+        .bind(pool_id)
+        .fetch_one(db)
+        .await
+        .map_err(super::db_err)?;
+
+    tracingx::info!(
+        pool = %pool_row.name,
+        year,
+        revision = row.1,
+        pairings = pairings.len(),
+        "past draw backfilled"
+    );
+
+    Ok(Exchange {
+        id: row.0,
+        pool_id,
+        pool_name: pool_row.name,
+        pool_slug: pool_row.slug,
+        year,
+        revision: row.1,
+        letter,
+        participants,
+        exclusions: vec![],
+        pairings,
+        config: None,
+        seed: None,
+    })
+}
+
 #[cfg(all(test, feature = "server"))]
 mod tests {
     use super::*;
@@ -431,5 +583,73 @@ mod tests {
             exchange(5, 3, 2026, 1),
         ];
         assert_eq!(only_current_revisions(rows).len(), 3);
+    }
+
+    fn pairs(entries: &[(&str, &str)]) -> Vec<crate::model::Pairing> {
+        entries
+            .iter()
+            .map(|(giver, receiver)| crate::model::Pairing {
+                giver: (*giver).to_string(),
+                receiver: (*receiver).to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_well_formed_backfill_is_accepted() {
+        let ring = pairs(&[("Anne", "Claire"), ("Claire", "Noel"), ("Noel", "Anne")]);
+        assert!(validate_backfill(&ring).is_ok());
+    }
+
+    #[test]
+    fn a_backfill_may_be_incomplete() {
+        // Old paper records often are: two entries that go nowhere in particular.
+        let partial = pairs(&[("Anne", "Claire"), ("Noel", "Grant")]);
+        assert!(
+            validate_backfill(&partial).is_ok(),
+            "a partial record is still worth having"
+        );
+    }
+
+    #[test]
+    fn nobody_gives_to_themselves() {
+        let err = validate_backfill(&pairs(&[("Anne", "Anne")])).unwrap_err();
+        assert!(err.contains("Anne"), "the message should name the offender: {err}");
+    }
+
+    #[test]
+    fn a_giver_cannot_appear_twice() {
+        let err = validate_backfill(&pairs(&[("Anne", "Claire"), ("Anne", "Noel")])).unwrap_err();
+        assert!(err.contains("Anne"));
+    }
+
+    #[test]
+    fn two_people_cannot_give_to_the_same_person() {
+        let err = validate_backfill(&pairs(&[("Anne", "Grant"), ("Noel", "Grant")])).unwrap_err();
+        assert!(err.contains("Grant"));
+    }
+
+    #[test]
+    fn an_empty_backfill_is_rejected() {
+        assert!(validate_backfill(&[]).is_err());
+    }
+
+    #[test]
+    fn blank_names_are_rejected() {
+        assert!(validate_backfill(&pairs(&[("Anne", "   ")])).is_err());
+        assert!(validate_backfill(&pairs(&[("", "Anne")])).is_err());
+    }
+
+    #[test]
+    fn participants_are_everyone_named_once_each() {
+        let ring = pairs(&[("Noel", "Anne"), ("Anne", "Claire"), ("Claire", "Noel")]);
+        assert_eq!(backfill_participants(&ring), vec!["Anne", "Claire", "Noel"]);
+    }
+
+    #[test]
+    fn participants_include_receivers_who_never_gave() {
+        // A one-sided record still tells us Grant was there.
+        let partial = pairs(&[("Anne", "Grant")]);
+        assert_eq!(backfill_participants(&partial), vec!["Anne", "Grant"]);
     }
 }

--- a/christmas/src/server/mod.rs
+++ b/christmas/src/server/mod.rs
@@ -7,7 +7,7 @@ mod pools;
 mod relationships;
 mod session;
 
-pub use draw::{exchange_detail, list_exchanges, list_year, run_draw};
+pub use draw::{exchange_detail, list_exchanges, list_year, record_past_draw, run_draw};
 pub use letters::{list_all_excluded_letters, list_excluded_letters, set_excluded_letters};
 pub use participants::{add_participant, list_participants, remove_participant};
 pub use pools::{add_member, create_pool, delete_pool, list_memberships, list_pools, pool_detail, remove_member};


### PR DESCRIPTION
Adds a **Backfill a past year** section to the Manage page, letting administrators enter who gave to whom in years that predate the app.

Once recorded, a backfilled year is indistinguishable from a normally drawn one: the "no repeat receivers" constraint can see it, and its letter is excluded from future draws. Entries are stored through the same revision counter as a regular draw, so recording the same year twice produces a second revision rather than overwriting the first.

The form lays out one row per pool member in a responsive grid. Receivers are chosen from a dropdown; leaving a row blank omits that person from the record, since old paper records are often incomplete. Duplicate receivers are flagged inline before saving rather than surfaced as a server error. The year and letter fields are editable, and if a record already exists for the chosen pool and year a notice appears with a link to load it for editing.

On the server side, `record_past_draw` validates that the submitted pairings form a valid partial permutation — no self-gifts, no giver appearing twice, no receiver appearing twice — before inserting. `config` and `seed` are left null rather than invented, which causes the pool page to omit the "How it was drawn" line for those years instead of displaying something untrue.