### PR TITLE
[christmas] Hide "Manage" nav link from viewers and tighten API allowlist to exact names

### DIFF
--- a/christmas/src/app.rs
+++ b/christmas/src/app.rs
@@ -1,8 +1,10 @@
 use dioxus::prelude::*;
 
 use crate::{
+    auth::Role,
     components::{Snowfall, StringLights},
     pages::{Admin, History, Home, Login, PoolPage, Reveal, YearPage},
+    server,
 };
 
 const MAIN_CSS: Asset = asset!("/assets/main.css");
@@ -54,6 +56,12 @@ pub fn App() -> Element {
 
 #[component]
 fn Shell() -> Element {
+    // Hidden rather than merely unhelpful: a viewer clicking "Manage" used to
+    // land on a page of permission errors. The server-side guard is still what
+    // enforces this — see `auth::required_access`.
+    let role = use_resource(server::my_role);
+    let is_manager = matches!(&*role.read(), Some(Ok(Role::Manager)));
+
     rsx! {
         nav { class: "navbar",
             Link { to: Route::Home {}, class: "navbar-brand",
@@ -62,7 +70,9 @@ fn Shell() -> Element {
             div { class: "navbar-links",
                 Link { to: Route::Home {}, active_class: "active", "This year" }
                 Link { to: Route::History {}, active_class: "active", "History" }
-                Link { to: Route::Admin {}, active_class: "active", "Manage" }
+                if is_manager {
+                    Link { to: Route::Admin {}, active_class: "active", "Manage" }
+                }
                 // A form, not a link: signing out changes state, and this keeps
                 // the whole auth flow free of JavaScript.
                 form { method: "post", action: "/auth/logout", class: "signout",

--- a/christmas/src/auth.rs
+++ b/christmas/src/auth.rs
@@ -33,11 +33,36 @@ pub enum Access {
 
 pub const COOKIE_NAME: &str = "christmas_session";
 
+/// The only server functions a viewer may call.
+///
+/// Named individually rather than matched by a `list_` prefix: the manage page
+/// reads people, relationships, memberships and excluded letters through
+/// `list_*` functions too, and a prefix rule handed all of that to anyone with
+/// the family password.
+const VIEWER_ENDPOINTS: [&str; 6] = [
+    "list_pools",
+    "list_year",
+    "list_exchanges",
+    "pool_detail",
+    "exchange_detail",
+    "my_role",
+];
+
+/// Recovers a server function's name from its request path.
+///
+/// Dioxus appends a decimal hash to each endpoint (`list_pools117422…`), so
+/// trimming the trailing digits gives the name back and lets the allowlist
+/// match exactly. Exactness is the point: as a prefix, `list_exchanges` is one
+/// typo away from also admitting `list_excluded_letters`.
+fn server_fn_name(endpoint: &str) -> &str {
+    endpoint.trim_end_matches(|c: char| c.is_ascii_digit())
+}
+
 /// Classifies a request path.
 ///
-/// Deliberately fails closed: anything under `/api` that is not a known
-/// read-only endpoint requires a manager, so adding a server function without
-/// thinking about auth denies access rather than granting it.
+/// Deliberately fails closed: anything under `/api` that is not on the viewer
+/// allowlist requires a manager, so adding a server function without thinking
+/// about auth denies access rather than granting it.
 pub fn required_access(path: &str) -> Access {
     if path == "/login"
         || path.starts_with("/auth/")
@@ -50,12 +75,7 @@ pub fn required_access(path: &str) -> Access {
     }
 
     if let Some(endpoint) = path.strip_prefix("/api/") {
-        // Server function paths are `<name><hash>`, so match on the name prefix.
-        if endpoint.starts_with("list_")
-            || endpoint.starts_with("pool_detail")
-            || endpoint.starts_with("exchange_detail")
-            || endpoint.starts_with("my_role")
-        {
+        if VIEWER_ENDPOINTS.contains(&server_fn_name(endpoint)) {
             return Access::Viewer;
         }
         return Access::Manager;
@@ -387,6 +407,7 @@ mod tests {
     fn mutating_endpoints_require_a_manager() {
         for path in [
             "/api/run_draw1",
+            "/api/record_past_draw1",
             "/api/create_pool1",
             "/api/delete_pool1",
             "/api/add_participant1",
@@ -396,6 +417,36 @@ mod tests {
         ] {
             assert_eq!(required_access(path), Access::Manager, "{path} must be manager-only");
         }
+    }
+
+    /// The manage page reads through `list_*` too. A prefix rule handed the
+    /// whole roster — and everyone's relationships — to the family password.
+    #[test]
+    fn reads_only_the_manage_page_needs_require_a_manager() {
+        for path in [
+            "/api/list_participants1",
+            "/api/list_relationships1",
+            "/api/list_memberships1",
+            "/api/list_excluded_letters1",
+            "/api/list_all_excluded_letters1",
+        ] {
+            assert_eq!(required_access(path), Access::Manager, "{path} must be manager-only");
+        }
+    }
+
+    /// `list_exchanges` is viewer-visible and `list_excluded_letters` is not,
+    /// and they share seven characters of prefix.
+    #[test]
+    fn the_allowlist_matches_whole_names_not_prefixes() {
+        assert_eq!(required_access("/api/list_exchanges1"), Access::Viewer);
+        assert_eq!(required_access("/api/list_excluded_letters1"), Access::Manager);
+        assert_eq!(required_access("/api/list_pools_and_secrets1"), Access::Manager);
+    }
+
+    #[test]
+    fn the_hash_suffix_is_not_part_of_the_name() {
+        assert_eq!(server_fn_name("list_pools11742215028865194505"), "list_pools");
+        assert_eq!(server_fn_name("my_role"), "my_role");
     }
 
     /// The property that makes this safe to extend.

--- a/christmas/src/pages/admin.rs
+++ b/christmas/src/pages/admin.rs
@@ -2,6 +2,8 @@ use dioxus::prelude::*;
 
 use super::current_year;
 use crate::{
+    app::Route,
+    auth::Role,
     components::{
         BackfillSection, DrawSection, LettersSection, ParticipantsSection, PoolsSection, RelationshipsSection,
     },
@@ -17,8 +19,43 @@ fn err_of<T>(resource: Option<&Result<T, ServerFnError>>) -> Option<String> {
     }
 }
 
+/// The manage page, behind a role check.
+///
+/// The middleware only sees a request when the browser asks for `/admin`
+/// directly; arriving through the client-side router never touches it. So the
+/// page checks for itself, and the reads it needs live in [`ManageBody`] — a
+/// viewer must not fire them at all, only to watch them come back 403.
 #[component]
 pub fn Admin() -> Element {
+    let role = use_resource(server::my_role);
+
+    rsx! {
+        match &*role.read() {
+            Some(Ok(Role::Manager)) => rsx! { ManageBody {} },
+            Some(Ok(Role::Viewer)) => rsx! {
+                header { class: "hero",
+                    div { class: "hero-copy",
+                        p { class: "eyebrow", "Behind the curtain" }
+                        h1 { "Not your side of the curtain." }
+                        p {
+                            "Running the draw needs the manager password. Ask whoever looks after the exchange."
+                        }
+                        Link {
+                            class: "reveal-cta",
+                            to: Route::Login { next: Some("/admin".to_string()), error: None },
+                            "Sign in as manager →"
+                        }
+                    }
+                }
+            },
+            Some(Err(e)) => rsx! { div { class: "error-box", "Couldn't check your access: {e}" } },
+            None => rsx! { div { class: "loading", "Checking…" } },
+        }
+    }
+}
+
+#[component]
+fn ManageBody() -> Element {
     let mut pools = use_resource(server::list_pools);
     let mut participants = use_resource(server::list_participants);
     let mut relationships = use_resource(server::list_relationships);


### PR DESCRIPTION
## Hide the "Manage" nav link from viewers and show a friendly gate on the admin page

Previously, anyone signed in with the family (viewer) password could see the "Manage" link in the navbar and click through to a page full of permission errors. This tightens that up in two places:

- **Navbar**: The "Manage" link is now only rendered when the current user has the `Manager` role, fetched via `my_role` on shell load.
- **Admin page**: Rather than immediately firing off all its data-fetching resources (which would return 403s for viewers), the page now checks the role first. Managers see the full manage UI (moved into `ManageBody`); viewers see a friendly message explaining they need the manager password, with a direct link to sign in as manager.

The server-side middleware remains the true enforcement boundary — this is purely a UX improvement so viewers aren't greeted with a wall of errors.

### Auth allowlist fix

The previous viewer endpoint check used `starts_with("list_")`, which inadvertently granted viewers access to `list_participants`, `list_relationships`, `list_memberships`, `list_excluded_letters`, and `list_all_excluded_letters` — data that should only be visible to managers. The allowlist is now an explicit set of named endpoints matched after stripping the Dioxus-appended numeric hash suffix, so only the intended six endpoints are viewer-accessible. New tests cover exact-name matching, hash stripping, and the specific case where `list_exchanges` and `list_excluded_letters` share a long common prefix.