### PR TITLE
[christmas] drop the "Slug" column from the admin pools table

### DIFF
--- a/christmas/src/components/pools.rs
+++ b/christmas/src/components/pools.rs
@@ -1,6 +1,6 @@
 use dioxus::prelude::*;
 
-use crate::{model::Pool, server};
+use crate::{app::Route, model::Pool, server};
 
 #[component]
 pub fn PoolsSection(pools: Vec<Pool>, on_change: EventHandler<()>) -> Element {
@@ -60,7 +60,6 @@ pub fn PoolsSection(pools: Vec<Pool>, on_change: EventHandler<()>) -> Element {
                         thead {
                             tr {
                                 th { "Name" }
-                                th { "Slug" }
                                 th { "Members" }
                                 th { "" }
                             }
@@ -71,8 +70,12 @@ pub fn PoolsSection(pools: Vec<Pool>, on_change: EventHandler<()>) -> Element {
                                     let id = pool.id;
                                     rsx! {
                                         tr { key: "{id}",
-                                            td { "{pool.name}" }
-                                            td { class: "mono muted", "{pool.slug}" }
+                                            td {
+                                                Link {
+                                                    to: Route::PoolPage { slug: pool.slug.clone() },
+                                                    "{pool.name}"
+                                                }
+                                            }
                                             td { class: "mono", "{pool.member_count}" }
                                             td {
                                                 button {


### PR DESCRIPTION
Removes the last user-facing use of the word "slug". The admin Pools table showed a `Slug` column with the raw value — developer vocabulary a pool manager has no reason to know.

The column's only practical use was navigating to a pool, so the **Name** cell is now a link to `/pools/:slug` and the raw slug is no longer displayed. The value itself is unchanged: it still keys the route, the model, and the tests.

Every other occurrence of `slug` in `christmas` is internal (route parameter, `Pool::slug`, `Exchange::pool_slug`) and never rendered.

Checks: `cargo clippy -p christmas --all-features --all-targets` clean, `cargo +nightly fmt --all` applied, `cargo test -p christmas --lib` 50/50 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)