### PR TITLE
[baseball] make the AI's off-plate pitches actually miss the zone

### DIFF
--- a/baseball/src/game/plugins/baseball/flow.rs
+++ b/baseball/src/game/plugins/baseball/flow.rs
@@ -51,10 +51,36 @@ fn ai_pitch_plan(rng: &mut RandomSource) -> pitch::PitchPlan {
             rng.range(pitch::ZONE_BOTTOM + 0.15, pitch::ZONE_TOP - 0.15),
         )
     } else {
-        // Just off the plate: tempting, but a ball if the batter lays off.
-        Vec2::new(rng.range(-1.55, 1.55), rng.range(1.05, 4.05))
+        ai_miss_target(rng)
     };
     pitch::PitchPlan { kind, target }
+}
+
+/// A pitch aimed deliberately off the plate: close enough to tempt a swing, but
+/// a ball if the batter lays off.
+///
+/// Aims past one chosen edge rather than sampling a rectangle around the plate.
+/// A rectangle drawn wide enough to be tempting also covers the zone, so about a
+/// third of these "misses" used to finish over the plate for a called strike —
+/// which put the AI near 73% strikes when the mix above intends 60%.
+fn ai_miss_target(rng: &mut RandomSource) -> Vec2 {
+    /// How far past the edge the ball finishes: clear of the zone, still hittable.
+    const NEAR: f32 = 0.06;
+    const FAR: f32 = 0.55;
+    /// How far a miss ranges along the edge it is missing off, so that inside and
+    /// outside pitches are not all belt high.
+    const ALONG: f32 = 0.3;
+
+    let miss = rng.range(NEAR, FAR);
+    let across = rng.range(-(pitch::ZONE_HALF_WIDTH + ALONG), pitch::ZONE_HALF_WIDTH + ALONG);
+    let up = rng.range(pitch::ZONE_BOTTOM - ALONG, pitch::ZONE_TOP + ALONG);
+
+    match rng.pick(&[0u8, 1, 2, 3]) {
+        0 => Vec2::new(pitch::ZONE_HALF_WIDTH + miss, up),
+        1 => Vec2::new(-(pitch::ZONE_HALF_WIDTH + miss), up),
+        2 => Vec2::new(across, pitch::ZONE_TOP + miss),
+        _ => Vec2::new(across, pitch::ZONE_BOTTOM - miss),
+    }
 }
 
 /// Whether the AI batter offers at this pitch, and how well it times it.
@@ -476,6 +502,22 @@ mod tests {
             "the AI threw {:.0}% strikes, which is not pitching",
             rate * 100.0
         );
+    }
+
+    /// The strike rate above only holds if a pitch meant to miss actually misses;
+    /// when it did not, the intended 60% in-zone mix came out nearer 73%.
+    #[test]
+    fn a_pitch_meant_to_miss_actually_misses() {
+        let mut rng = rng();
+        for _ in 0..500 {
+            let target = ai_miss_target(&mut rng);
+            assert!(!pitch::in_zone(target), "meant to miss, but {target:?} is a strike");
+            assert!(target.x.abs() <= pitch::AIM_LIMIT_X, "aimed at {target:?}");
+            assert!(
+                (pitch::AIM_LIMIT_LOW..=pitch::AIM_LIMIT_HIGH).contains(&target.y),
+                "aimed at {target:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`the_ai_pitcher_throws_strikes_and_balls_in_a_sane_mix` is flaky on `main` — it failed in roughly **1 run in 4** (measured 3/12, then 2/12 across 24 runs), always by overshooting the upper bound (76–79% vs. the asserted 75% ceiling).

It is not just unlucky sampling. `ai_pitch_plan` aims in the zone 60% of the time and "just off the plate" the rest, but the off-plate branch sampled a rectangle spanning `x ±1.55` by `y 1.05..4.05` — which fully contains the strike zone (`x ±0.83`, `y 1.6..3.4`). The zone is ~32% of that rectangle's area, so:

```
in-zone rate = 0.60 + 0.40 × 0.32 ≈ 0.73
```

The AI was throwing ~73% strikes when the mix intends 60%, landing right on the test's ceiling — hence a coin-flip failure rather than a clean pass or a clean fail.

## Fix

Aim past one chosen edge (inside/outside/high/low) instead of sampling a rectangle around the plate, so a pitch meant to miss always misses. All four cases stay within `AIM_LIMIT_*`, so `the_ai_pitcher_never_aims_somewhere_unreachable` still holds. `HBP_X` is `-1.75`, beyond `AIM_LIMIT_X` of `1.7`, so hit-by-pitch was never reachable by aim and is unaffected.

Also adds `a_pitch_meant_to_miss_actually_misses`, which pins the invariant directly rather than leaving a statistical band as the only thing standing between this bug and CI.

## Verification

- Strike rate back to ~60%, comfortably inside the asserted `0.45..=0.75`
- Baseball suite **30/30 runs green** (was ~25% failure)
- `cargo +nightly fmt --all -- --check` clean; CI clippy reports no errors
- 99 baseball + 26 twotris tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)