### PR TITLE
[baseball] Add baseball_webui service to local monitoring stack with Caddy proxy

### DIFF
--- a/docker-local-monitoring/Caddyfile
+++ b/docker-local-monitoring/Caddyfile
@@ -39,6 +39,15 @@ https://postgres-exporter.myhome.com {
     reverse_proxy postgres_exporter:9187
 }
 
+http://baseball.myhome.com {
+    redir https://{host}{uri} permanent
+}
+
+https://baseball.myhome.com {
+    tls /etc/caddy/certs/cert.pem /etc/caddy/certs/key.pm
+    reverse_proxy baseball_webui:8080
+}
+
 http://node-exporter.myhome.com {
     redir https://{host}{uri} permanent
 }

--- a/docker-local-monitoring/README.md
+++ b/docker-local-monitoring/README.md
@@ -19,6 +19,22 @@ Local development environment with PostgreSQL, Prometheus, and Grafana.
 - Username: admin
 - Password: admin
 
+### Baseball webui
+- Port: 30800
+- Web UI: http://localhost:30800 (or https://baseball.myhome.com through Caddy)
+- Source: the `webui` crate in `sports/webui`, built from the workspace
+  `Dockerfile` at the repo root with `APP_NAME=webui`
+- Reads the `sports` database via `SPORTS_DATABASE_URL`, the same database the
+  `Sports PostgreSQL` Grafana datasource and the baseball dashboard use
+
+Because it is a `build:` service rather than a pulled image, it is not rebuilt
+automatically when the Rust source changes:
+
+    docker-compose build baseball_webui && docker-compose up -d baseball_webui
+
+The first build compiles the whole workspace plus the wasm bundle, so expect it
+to take a while; later builds reuse the cargo-chef dependency layer.
+
 ## Data Persistence
 
 All data is persisted in Docker volumes:

--- a/docker-local-monitoring/docker-compose.yml
+++ b/docker-local-monitoring/docker-compose.yml
@@ -111,6 +111,29 @@ services:
     networks:
       - monitoring
 
+  # Baseball/sports data explorer (the `webui` crate in sports/webui). Built
+  # from the workspace Dockerfile at the repo root, hence the `..` context.
+  baseball_webui:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        APP_NAME: webui
+    image: local-baseball-webui:latest
+    container_name: local-baseball-webui
+    restart: unless-stopped
+    environment:
+      SPORTS_DATABASE_URL: "postgresql://postgres:postgres@postgres:5432/sports"
+      PORT: 8080
+      IP: 0.0.0.0
+    ports:
+      - "127.0.0.1:30800:8080"
+    networks:
+      - monitoring
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   grafana:
     image: grafana/grafana:latest
     container_name: local-grafana

--- a/docker-local-monitoring/update-hosts.sh
+++ b/docker-local-monitoring/update-hosts.sh
@@ -9,6 +9,7 @@ HOSTS_ENTRIES="
 127.0.0.1 pgadmin.myhome.com
 127.0.0.1 postgres-exporter.myhome.com
 127.0.0.1 node-exporter.myhome.com
+127.0.0.1 baseball.myhome.com
 "
 
 echo "Adding entries to /etc/hosts..."
@@ -19,3 +20,4 @@ echo "  - https://prometheus.myhome.com"
 echo "  - https://pgadmin.myhome.com"
 echo "  - https://postgres-exporter.myhome.com"
 echo "  - https://node-exporter.myhome.com"
+echo "  - https://baseball.myhome.com"


### PR DESCRIPTION
Adds the `baseball_webui` service to the local monitoring Docker Compose stack, exposing the `webui` crate from the `sports/webui` workspace as a locally accessible web UI.

The service is built from the workspace `Dockerfile` at the repo root using `APP_NAME=webui`, connects to the existing `sports` PostgreSQL database via `SPORTS_DATABASE_URL`, and is available on port `30800` locally or via `https://baseball.myhome.com` through Caddy. The `update-hosts.sh` script and Caddy configuration are updated to include the new hostname, and the README documents how to build and rebuild the service, including a note about the longer initial build time due to full workspace and WASM compilation.