### PR TITLE
[christmas] Add hand-adjustment UI and server functions for swapping two people in a recorded draw

### DIFF
--- a/christmas/migrations/004_manual_adjustments.sql
+++ b/christmas/migrations/004_manual_adjustments.sql
@@ -1,0 +1,13 @@
+-- Hand adjustments to a draw.
+--
+-- A swap is recorded the same way a re-draw is: a new revision, with the
+-- previous one left intact. These two columns are what distinguish the two, so
+-- an adjusted year can say so instead of quietly presenting itself as something
+-- the solver produced.
+ALTER TABLE exchange ADD COLUMN adjusted_from INTEGER REFERENCES exchange(id) ON DELETE SET NULL;
+ALTER TABLE exchange ADD COLUMN adjustment_note TEXT;
+
+COMMENT ON COLUMN exchange.adjusted_from IS
+    'The revision this one was hand-edited from. NULL for draws the solver produced.';
+COMMENT ON COLUMN exchange.adjustment_note IS
+    'What the edit was, in words, for the manage page and the audit trail.';

--- a/christmas/src/auth.rs
+++ b/christmas/src/auth.rs
@@ -408,6 +408,8 @@ mod tests {
         for path in [
             "/api/run_draw1",
             "/api/record_past_draw1",
+            "/api/preview_swap1",
+            "/api/apply_swap1",
             "/api/create_pool1",
             "/api/delete_pool1",
             "/api/add_participant1",

--- a/christmas/src/components/adjust.rs
+++ b/christmas/src/components/adjust.rs
@@ -1,0 +1,289 @@
+//! Trading two people's places in a ring, after the draw has run.
+//!
+//! The draw is a good solver but a bad judge of circumstance — somebody moved,
+//! somebody is unwell, somebody already bought the wrong present. Re-running the
+//! whole thing to fix one pairing throws away thirteen good ones, so this moves
+//! only the two that need moving.
+
+use dioxus::prelude::*;
+
+use crate::{
+    model::{Exchange, Pool, SwapPreview, only_current_revisions},
+    server,
+};
+
+/// A hand adjustment to one recorded draw.
+///
+/// Draws are passed in rather than fetched: a `use_resource` whose only input is
+/// a component prop registers no reactive dependency, so it would never re-run
+/// once the list loaded — the same trap documented in `letters.rs`.
+#[component]
+pub fn AdjustSection(pools: Vec<Pool>, exchanges: Vec<Exchange>, on_change: EventHandler<()>) -> Element {
+    // Only the live revision of each year can be adjusted, and only if it has
+    // pairings to adjust — the server enforces both, but offering the choice and
+    // then refusing it would be a poor way to say so.
+    let adjustable: Vec<Exchange> = only_current_revisions(exchanges)
+        .into_iter()
+        .filter(|e| !e.pairings.is_empty())
+        .collect();
+
+    let first = adjustable.first().map(|e| e.id);
+    let mut chosen = use_signal(|| None::<i32>);
+    let mut a = use_signal(String::new);
+    let mut b = use_signal(String::new);
+    let mut preview = use_signal(|| None::<SwapPreview>);
+    let mut despite = use_signal(|| false);
+    let mut busy = use_signal(|| false);
+    let mut error = use_signal(|| None::<String>);
+    let mut saved = use_signal(|| None::<Exchange>);
+
+    // Derived, not synced through an effect — see the note in `letters.rs`.
+    let draw_id = move || chosen().or(first);
+    let draw = adjustable.iter().find(|e| Some(e.id) == draw_id()).cloned();
+
+    // Swapping across rings would splice them into one, so the second dropdown
+    // offers only the first person's own ring. In `Grand` mode that is everyone,
+    // which is the common case; in `Multiple` mode it keeps the rings intact.
+    let rings = draw.as_ref().map(Exchange::cycles).unwrap_or_default();
+    let ring_of_a: Vec<String> = rings
+        .iter()
+        .find(|ring| ring.iter().any(|name| *name == a()))
+        .cloned()
+        .unwrap_or_default();
+    let partners: Vec<String> = ring_of_a.iter().filter(|name| **name != a()).cloned().collect();
+
+    let everyone: Vec<String> = draw.as_ref().map(|d| d.participants.clone()).unwrap_or_default();
+    let ready = !a().is_empty() && !b().is_empty() && a() != b();
+
+    let mut reset = move || {
+        preview.set(None);
+        despite.set(false);
+        error.set(None);
+        saved.set(None);
+    };
+
+    let do_preview = move |_| {
+        let (Some(id), first, second) = (draw_id(), a(), b()) else {
+            return;
+        };
+        busy.set(true);
+        error.set(None);
+        saved.set(None);
+        spawn(async move {
+            match server::preview_swap(id, first, second).await {
+                Ok(p) => {
+                    // A fresh preview invalidates any previous override.
+                    despite.set(false);
+                    preview.set(Some(p));
+                }
+                Err(e) => {
+                    preview.set(None);
+                    error.set(Some(e.to_string()));
+                }
+            }
+            busy.set(false);
+        });
+    };
+
+    let apply = move |_| {
+        let (Some(id), first, second) = (draw_id(), a(), b()) else {
+            return;
+        };
+        let confirmed = despite();
+        busy.set(true);
+        error.set(None);
+        spawn(async move {
+            match server::apply_swap(id, first, second, confirmed).await {
+                Ok(exchange) => {
+                    saved.set(Some(exchange));
+                    preview.set(None);
+                    despite.set(false);
+                    a.set(String::new());
+                    b.set(String::new());
+                    error.set(None);
+                    on_change.call(());
+                }
+                Err(e) => error.set(Some(e.to_string())),
+            }
+            busy.set(false);
+        });
+    };
+
+    let pool_label = |exchange: &Exchange| {
+        let name = pools
+            .iter()
+            .find(|p| p.id == exchange.pool_id)
+            .map_or(exchange.pool_name.clone(), |p| p.name.clone());
+        format!("{name} · {}", exchange.year)
+    };
+
+    rsx! {
+        div { class: "panel",
+            h3 { "Adjust a draw by hand" }
+            p { class: "muted", style: "font-size: 0.85rem; margin-top: -0.5rem",
+                "Swap two people's places in the ring when the draw is right but life isn't. Everyone else keeps who they've got. The change is saved as a new revision, so the original is still on the record."
+            }
+
+            if let Some(e) = error() {
+                div { class: "error-box", "{e}" }
+            }
+
+            if adjustable.is_empty() {
+                p { class: "muted", "Nothing to adjust yet — run a draw first." }
+            } else {
+                div { class: "field-row",
+                    label { "Draw" }
+                    select {
+                        value: draw_id().map_or_else(String::new, |v| v.to_string()),
+                        onchange: move |e| {
+                            chosen.set(e.value().parse().ok());
+                            // Names from the old draw mean nothing in the new one.
+                            a.set(String::new());
+                            b.set(String::new());
+                            reset();
+                        },
+                        for exchange in adjustable.iter() {
+                            option { key: "{exchange.id}", value: "{exchange.id}", "{pool_label(exchange)}" }
+                        }
+                    }
+                }
+
+                div { class: "field-row",
+                    label { "Swap" }
+                    select {
+                        value: "{a}",
+                        onchange: move |e| {
+                            a.set(e.value());
+                            // The new person may be in a different ring.
+                            b.set(String::new());
+                            reset();
+                        },
+                        option { value: "", "—" }
+                        for name in everyone.iter() {
+                            option { key: "{name}", value: "{name}", "{name}" }
+                        }
+                    }
+                    label { "with" }
+                    select {
+                        value: "{b}",
+                        disabled: a().is_empty(),
+                        onchange: move |e| {
+                            b.set(e.value());
+                            reset();
+                        },
+                        option { value: "", "—" }
+                        for name in partners.iter() {
+                            option { key: "{name}", value: "{name}", "{name}" }
+                        }
+                    }
+                    button { disabled: busy() || !ready, onclick: do_preview,
+                        if busy() { "Working…" } else { "Preview" }
+                    }
+                }
+
+                if rings.len() > 1 && !a().is_empty() {
+                    div { class: "notice",
+                        "This draw has {rings.len()} rings. Only the {partners.len()} others in {a}'s ring are offered — swapping across rings would join them into one."
+                    }
+                }
+
+                if let Some(p) = preview() {
+                    SwapPreviewPanel {
+                        preview: p,
+                        despite: despite(),
+                        busy: busy(),
+                        on_despite: move |v| despite.set(v),
+                        on_apply: apply,
+                    }
+                }
+            }
+
+            if let Some(exchange) = saved() {
+                div { class: "notice", style: "margin-top: 1rem",
+                    if let Some(note) = exchange.adjustment_note.as_ref() {
+                        "{note}. "
+                    }
+                    "Saved as revision {exchange.revision} of {exchange.year}."
+                }
+            }
+        }
+    }
+}
+
+/// What the swap would do, and the confirmation it needs.
+///
+/// Split out because a swap moves up to four pairings, not the two its name
+/// suggests, and showing that before it is saved is the whole point of having a
+/// preview step.
+#[component]
+fn SwapPreviewPanel(
+    preview: SwapPreview,
+    despite: bool,
+    busy: bool,
+    on_despite: EventHandler<bool>,
+    on_apply: EventHandler<MouseEvent>,
+) -> Element {
+    let blocked = !preview.violations.is_empty() && !despite;
+
+    rsx! {
+        div { style: "margin-top: 1rem",
+            div { class: "section-head",
+                h2 { style: "font-size: 1.1rem", "Swapping {preview.a} and {preview.b}" }
+                span { class: "count", "{preview.changes.len()} pairings move" }
+            }
+
+            div { class: "table-scroll",
+                table { class: "data-table",
+                    thead {
+                        tr {
+                            th { "Giver" }
+                            th { "Was giving to" }
+                            th { "Would give to" }
+                        }
+                    }
+                    tbody {
+                        for change in preview.changes.iter() {
+                            tr { key: "{change.giver}",
+                                td { class: "giver", "{change.giver}" }
+                                td { class: "muted", "{change.was}" }
+                                td { class: "receiver", "{change.now}" }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if preview.changes.is_empty() {
+                div { class: "notice", "That swap changes nothing." }
+            }
+
+            if !preview.violations.is_empty() {
+                div { class: "error-box", style: "margin-top: 1rem",
+                    strong { "This breaks the rules the draw ran under:" }
+                    ul { style: "margin: 0.5rem 0 0; padding-left: 1.1rem",
+                        for violation in preview.violations.iter() {
+                            li { key: "{violation.giver}-{violation.receiver}",
+                                "{violation.giver} would give to {violation.receiver} — {violation.reason}"
+                            }
+                        }
+                    }
+                }
+                label { class: "muted", style: "display: block; font-size: 0.85rem; margin-bottom: 1rem",
+                    input {
+                        r#type: "checkbox",
+                        checked: despite,
+                        style: "margin-right: 0.4rem",
+                        onchange: move |e| on_despite.call(e.checked()),
+                    }
+                    "I know — do it anyway."
+                }
+            }
+
+            button {
+                disabled: busy || blocked || preview.changes.is_empty(),
+                onclick: move |e| on_apply.call(e),
+                if busy { "Saving…" } else { "Apply the swap" }
+            }
+        }
+    }
+}

--- a/christmas/src/components/mod.rs
+++ b/christmas/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod adjust;
 mod backfill;
 mod cycle_graph;
 mod decor;
@@ -7,6 +8,7 @@ mod participants;
 mod pools;
 mod relationships;
 
+pub use adjust::AdjustSection;
 pub use backfill::BackfillSection;
 pub use cycle_graph::{CycleBoard, RevealRing};
 pub use decor::{Snowfall, StringLights};

--- a/christmas/src/matching.rs
+++ b/christmas/src/matching.rs
@@ -392,6 +392,187 @@ impl Solver<'_> {
     }
 }
 
+/// One receiver a proposed swap would change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SwapChange {
+    pub giver: String,
+    pub was: String,
+    pub now: String,
+}
+
+/// A rule the swap would break.
+///
+/// Reported rather than enforced. Whoever is adjusting the draw by hand knows
+/// something the solver did not — somebody moved away, somebody is unwell — and
+/// the rules exist to serve that judgement, not to overrule it. The caller
+/// decides whether to require confirmation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SwapViolation {
+    pub giver: String,
+    pub receiver: String,
+    pub reason: BlockReason,
+}
+
+/// What swapping two people would do to a draw.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Swap {
+    /// The full pairing list afterwards, in the same giver order as the input.
+    pub pairings: Vec<(String, String)>,
+    /// Only the entries that actually move.
+    pub changes: Vec<SwapChange>,
+    pub violations: Vec<SwapViolation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwapError {
+    SamePerson {
+        name: String,
+    },
+    NotInDraw {
+        name: String,
+    },
+    /// Swapping across two rings would splice them into one, which is a
+    /// structural change to the draw rather than the local edit it looks like.
+    DifferentRings {
+        a: String,
+        b: String,
+    },
+    /// The stored pairings are not a clean set of rings, so there is nothing
+    /// coherent to swap within.
+    Malformed,
+}
+
+impl std::fmt::Display for SwapError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SamePerson { name } => write!(f, "{name} is already {name} — pick two different people"),
+            Self::NotInDraw { name } => write!(f, "{name} is not in this draw"),
+            Self::DifferentRings { a, b } => write!(
+                f,
+                "{a} and {b} are in different rings. Swapping them would join the two rings into one — re-run the draw instead"
+            ),
+            Self::Malformed => write!(
+                f,
+                "this draw's pairings do not form complete rings, so nothing can be swapped"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SwapError {}
+
+/// Trades two people's places within their ring.
+///
+/// In a ring `A → B → C → D → A`, swapping `B` and `D` gives
+/// `A → D → C → B → A`: each keeps their own position's giver and receiver, and
+/// they change places. This is the edit somebody means by "put those two the
+/// other way round" — it moves at most four edges and leaves everyone else's
+/// pairing alone.
+///
+/// The ring itself is untouched: same members, same length, same count. So a
+/// draw that satisfied its [`CycleMode`] before still satisfies it after, and
+/// nobody can end up giving to themselves. What a swap *can* break is the
+/// blocked-edge rules — a new edge may land on a spouse or repeat a recent
+/// year — so those are checked and returned in `violations` for the caller to
+/// present.
+pub fn swap_in_ring(
+    pairings: &[(String, String)],
+    a: &str,
+    b: &str,
+    blocked: &[BlockedEdge],
+) -> Result<Swap, SwapError> {
+    if a == b {
+        return Err(SwapError::SamePerson { name: a.to_string() });
+    }
+
+    let mut next: HashMap<&str, &str> = HashMap::with_capacity(pairings.len());
+    for (giver, receiver) in pairings {
+        if next.insert(giver.as_str(), receiver.as_str()).is_some() {
+            // Two entries for one giver: not a permutation.
+            return Err(SwapError::Malformed);
+        }
+    }
+
+    for name in [a, b] {
+        if !next.contains_key(name) {
+            return Err(SwapError::NotInDraw { name: name.to_string() });
+        }
+    }
+
+    // Walk forward from `a` until it comes back round. A partial record (the
+    // shape `backfill` deliberately permits) runs off the end instead, and a
+    // longer walk than there are people means the chain never closes.
+    let mut ring: Vec<&str> = vec![a];
+    let mut cur = next[a];
+    while cur != a {
+        ring.push(cur);
+        if ring.len() > next.len() {
+            return Err(SwapError::Malformed);
+        }
+        let Some(&onward) = next.get(cur) else {
+            return Err(SwapError::Malformed);
+        };
+        cur = onward;
+    }
+
+    // `a` is at 0 by construction, so only `b` needs locating.
+    let Some(b_at) = ring.iter().position(|name| *name == b) else {
+        return Err(SwapError::DifferentRings {
+            a: a.to_string(),
+            b: b.to_string(),
+        });
+    };
+    ring.swap(0, b_at);
+
+    // Rebuilt from the reordered ring; everyone outside it keeps what they had.
+    let mut swapped = next.clone();
+    for (i, giver) in ring.iter().enumerate() {
+        swapped.insert(*giver, ring[(i + 1) % ring.len()]);
+    }
+
+    let mut changes = Vec::new();
+    let mut new_pairings = Vec::with_capacity(pairings.len());
+
+    for (giver, was) in pairings {
+        let now = swapped[giver.as_str()];
+        if now == giver.as_str() {
+            // Unreachable for a well-formed ring of three or more, but a
+            // self-gift is the one outcome that must never be written.
+            return Err(SwapError::Malformed);
+        }
+        if now != was {
+            changes.push(SwapChange {
+                giver: giver.clone(),
+                was: was.clone(),
+                now: now.to_string(),
+            });
+        }
+        new_pairings.push((giver.clone(), now.to_string()));
+    }
+
+    // Only the edges that moved can newly break a rule; the rest were already
+    // acceptable when the draw ran.
+    let violations = changes
+        .iter()
+        .flat_map(|change| {
+            blocked
+                .iter()
+                .filter(move |edge| edge.giver == change.giver && edge.receiver == change.now)
+                .map(|edge| SwapViolation {
+                    giver: edge.giver.clone(),
+                    receiver: edge.receiver.clone(),
+                    reason: edge.reason,
+                })
+        })
+        .collect();
+
+    Ok(Swap {
+        pairings: new_pairings,
+        changes,
+        violations,
+    })
+}
+
 /// Picks the letter of the year.
 ///
 /// `excluded` is the pool's manually-disabled set; `already_used` is every
@@ -635,6 +816,272 @@ mod tests {
             for (a, b) in &couples {
                 for (g, r) in &draw.pairings {
                     assert!(!(g == a && r == b || g == b && r == a), "{a} and {b} are married");
+                }
+            }
+        }
+    }
+
+    fn ring(names: &[&str]) -> Vec<(String, String)> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(i, g)| ((*g).to_string(), names[(i + 1) % names.len()].to_string()))
+            .collect()
+    }
+
+    /// Compares by edge set. The two are the same draw however the list is
+    /// ordered — `ring` writes edges in walk order, `swap_in_ring` keeps the
+    /// giver order it was handed.
+    fn same_draw(got: &[(String, String)], want: &[(String, String)]) {
+        let as_map = |pairs: &[(String, String)]| -> std::collections::BTreeMap<String, String> {
+            pairs.iter().cloned().collect()
+        };
+        assert_eq!(as_map(got), as_map(want));
+    }
+
+    /// The example from the doc comment, worked by hand.
+    #[test]
+    fn a_swap_trades_two_places_in_the_ring() {
+        let before = ring(&["A", "B", "C", "D"]);
+        let after = swap_in_ring(&before, "B", "D", &[]).unwrap();
+
+        same_draw(&after.pairings, &ring(&["A", "D", "C", "B"]));
+        // A→D, D→C, C→B, B→A: every edge moves in a ring of four.
+        assert_eq!(after.changes.len(), 4);
+        assert!(after.violations.is_empty());
+    }
+
+    /// Callers diff the result against what they already had, so the list must
+    /// come back in the order it went in rather than in ring order.
+    #[test]
+    fn the_giver_order_of_the_input_is_preserved() {
+        let before = ring(&["A", "B", "C", "D", "E"]);
+        let after = swap_in_ring(&before, "B", "E", &[]).unwrap();
+
+        let givers = |pairs: &[(String, String)]| -> Vec<String> { pairs.iter().map(|(g, _)| g.clone()).collect() };
+        assert_eq!(givers(&after.pairings), givers(&before));
+    }
+
+    /// Neighbours are the case a naive "rewire the four edges" version gets
+    /// wrong — the general formula points somebody at themselves.
+    #[test]
+    fn adjacent_people_can_be_swapped() {
+        let before = ring(&["A", "B", "C", "D", "E"]);
+        let after = swap_in_ring(&before, "B", "C", &[]).unwrap();
+
+        same_draw(&after.pairings, &ring(&["A", "C", "B", "D", "E"]));
+        for (giver, receiver) in &after.pairings {
+            assert_ne!(giver, receiver, "nobody may end up giving to themselves");
+        }
+    }
+
+    #[test]
+    fn the_order_of_the_two_names_does_not_matter() {
+        let before = ring(&["A", "B", "C", "D", "E"]);
+        let one = swap_in_ring(&before, "B", "E", &[]).unwrap();
+        let other = swap_in_ring(&before, "E", "B", &[]).unwrap();
+        assert_eq!(one.pairings, other.pairings);
+    }
+
+    #[test]
+    fn swapping_twice_returns_the_original() {
+        let before = ring(&["A", "B", "C", "D", "E", "F"]);
+        let once = swap_in_ring(&before, "B", "E", &[]).unwrap();
+        let twice = swap_in_ring(&once.pairings, "B", "E", &[]).unwrap();
+        assert_eq!(twice.pairings, before);
+        assert!(!once.changes.is_empty());
+    }
+
+    /// The property that lets a swap be applied without re-running the solver:
+    /// it cannot turn a legal draw into an illegally-shaped one.
+    #[test]
+    fn a_swap_preserves_the_ring_structure() {
+        let participants = people(&["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]);
+
+        for min_len in [3usize, 5] {
+            for seed in 0..25 {
+                let draw = build_draw(&participants, &[], &cfg(CycleMode::Multiple { min_len }, seed)).unwrap();
+                let before: Vec<(String, String)> = draw.pairings.clone();
+                let shape = |pairs: &[(String, String)]| {
+                    let ex = exchange_of(pairs);
+                    let mut lens: Vec<usize> = ex.iter().map(Vec::len).collect();
+                    lens.sort_unstable();
+                    lens
+                };
+
+                for (i, a) in participants.iter().enumerate() {
+                    for b in participants.iter().skip(i + 1) {
+                        let Ok(swapped) = swap_in_ring(&before, a, b, &[]) else {
+                            // Different rings; refused, which is its own test.
+                            continue;
+                        };
+
+                        assert_eq!(shape(&swapped.pairings), shape(&before), "ring lengths must not change");
+
+                        let givers: HashSet<&str> = swapped.pairings.iter().map(|(g, _)| g.as_str()).collect();
+                        let receivers: HashSet<&str> = swapped.pairings.iter().map(|(_, r)| r.as_str()).collect();
+                        assert_eq!(givers.len(), participants.len());
+                        assert_eq!(receivers.len(), participants.len());
+                        for (g, r) in &swapped.pairings {
+                            assert_ne!(g, r);
+                        }
+                        for cycle in exchange_of(&swapped.pairings) {
+                            assert!(cycle.len() >= min_len, "swap produced a ring shorter than {min_len}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Cycle decomposition over a pairing list, for the structural assertions.
+    fn exchange_of(pairs: &[(String, String)]) -> Vec<Vec<String>> {
+        let next: HashMap<&str, &str> = pairs.iter().map(|(g, r)| (g.as_str(), r.as_str())).collect();
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut cycles = Vec::new();
+        for (start, _) in pairs {
+            if seen.contains(start.as_str()) {
+                continue;
+            }
+            let mut cycle = Vec::new();
+            let mut cur = start.as_str();
+            while seen.insert(cur) {
+                cycle.push(cur.to_string());
+                cur = next[cur];
+            }
+            cycles.push(cycle);
+        }
+        cycles
+    }
+
+    #[test]
+    fn a_swap_reports_the_rules_it_would_break() {
+        // A→B→C→D→A. Swapping B and D points A at D, and they are married.
+        let before = ring(&["A", "B", "C", "D"]);
+        let blocked = symmetric("A", "D", BlockReason::Spouse);
+
+        let swap = swap_in_ring(&before, "B", "D", &blocked).unwrap();
+        assert_eq!(swap.violations.len(), 1);
+        assert_eq!(swap.violations[0].giver, "A");
+        assert_eq!(swap.violations[0].receiver, "D");
+        assert_eq!(swap.violations[0].reason, BlockReason::Spouse);
+
+        // Reported, not refused — the caller decides.
+        same_draw(&swap.pairings, &ring(&["A", "D", "C", "B"]));
+    }
+
+    /// Edges that did not move were already legal, so they must not be
+    /// re-reported as though the swap caused them.
+    #[test]
+    fn untouched_edges_are_not_blamed_on_the_swap() {
+        let before = ring(&["A", "B", "C", "D", "E"]);
+        // C→D survives a swap of A and B, and is blocked from the outset.
+        let blocked = vec![BlockedEdge {
+            giver: "C".to_string(),
+            receiver: "D".to_string(),
+            reason: BlockReason::Manual,
+        }];
+
+        let swap = swap_in_ring(&before, "A", "B", &blocked).unwrap();
+        assert!(swap.changes.iter().all(|c| c.giver != "C"));
+        assert!(swap.violations.is_empty(), "{:?}", swap.violations);
+    }
+
+    #[test]
+    fn a_repeat_of_a_recent_year_is_reported_with_the_year() {
+        let before = ring(&["A", "B", "C", "D"]);
+        let blocked = vec![BlockedEdge {
+            giver: "A".to_string(),
+            receiver: "D".to_string(),
+            reason: BlockReason::RepeatOf { year: 2025 },
+        }];
+
+        let swap = swap_in_ring(&before, "B", "D", &blocked).unwrap();
+        assert_eq!(swap.violations[0].reason, BlockReason::RepeatOf { year: 2025 });
+    }
+
+    #[test]
+    fn swapping_across_rings_is_refused() {
+        let mut pairs = ring(&["A", "B", "C"]);
+        pairs.extend(ring(&["D", "E", "F"]));
+
+        let err = swap_in_ring(&pairs, "A", "E", &[]).unwrap_err();
+        assert_eq!(
+            err,
+            SwapError::DifferentRings {
+                a: "A".to_string(),
+                b: "E".to_string()
+            }
+        );
+        // The message has to explain why, since the UI offers every name.
+        assert!(err.to_string().contains("different rings"), "{err}");
+    }
+
+    #[test]
+    fn a_person_must_be_swapped_with_somebody_else() {
+        let pairs = ring(&["A", "B", "C"]);
+        assert_eq!(
+            swap_in_ring(&pairs, "A", "A", &[]).unwrap_err(),
+            SwapError::SamePerson { name: "A".to_string() }
+        );
+    }
+
+    #[test]
+    fn unknown_names_are_rejected() {
+        let pairs = ring(&["A", "B", "C"]);
+        assert_eq!(
+            swap_in_ring(&pairs, "A", "Zebedee", &[]).unwrap_err(),
+            SwapError::NotInDraw {
+                name: "Zebedee".to_string()
+            }
+        );
+    }
+
+    /// `record_past_draw` accepts an incomplete year on purpose, so a draw whose
+    /// chain runs off the end is a real thing to meet here.
+    #[test]
+    fn a_partial_record_cannot_be_swapped() {
+        let partial = vec![("A".to_string(), "B".to_string()), ("B".to_string(), "C".to_string())];
+        assert_eq!(swap_in_ring(&partial, "A", "B", &[]).unwrap_err(), SwapError::Malformed);
+    }
+
+    #[test]
+    fn a_duplicated_giver_is_rejected() {
+        let broken = vec![("A".to_string(), "B".to_string()), ("A".to_string(), "C".to_string())];
+        assert_eq!(swap_in_ring(&broken, "A", "B", &[]).unwrap_err(), SwapError::Malformed);
+    }
+
+    /// The real shape this was built for: one grand ring of fourteen.
+    #[test]
+    fn any_two_people_in_the_family_ring_can_trade_places() {
+        let participants = people(&[
+            "Claire", "Grant", "Anne", "Duncan", "Noel", "K-Lee", "Steve", "Linda", "Chris", "Jim", "Kari", "Meaghann",
+            "Alec", "Eric",
+        ]);
+        let couples = [
+            ("Claire", "Duncan"),
+            ("Anne", "Eric"),
+            ("Noel", "K-Lee"),
+            ("Steve", "Linda"),
+            ("Jim", "Kari"),
+        ];
+        let blocked: Vec<BlockedEdge> = couples
+            .iter()
+            .flat_map(|(a, b)| symmetric(a, b, BlockReason::Spouse))
+            .collect();
+
+        let draw = build_draw(&participants, &blocked, &cfg(CycleMode::Grand, 7)).unwrap();
+
+        for (i, a) in participants.iter().enumerate() {
+            for b in participants.iter().skip(i + 1) {
+                let swap = swap_in_ring(&draw.pairings, a, b, &blocked)
+                    .unwrap_or_else(|e| panic!("one grand ring holds everyone, so {a}/{b} should swap: {e}"));
+
+                // Whatever the solver's rules were, the swap only ever moves
+                // the four edges around the two who traded places.
+                assert!(swap.changes.len() <= 4, "{a}/{b} moved {} edges", swap.changes.len());
+                for (g, r) in &swap.pairings {
+                    assert_ne!(g, r);
                 }
             }
         }

--- a/christmas/src/model.rs
+++ b/christmas/src/model.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::matching::{CycleMode, DEFAULT_MIN_CYCLE_LEN, DrawConfig};
+pub use crate::matching::{CycleMode, DEFAULT_MIN_CYCLE_LEN, DrawConfig, SwapChange, SwapViolation};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Participant {
@@ -100,9 +100,45 @@ pub struct Exchange {
     pub pairings: Vec<Pairing>,
     pub config: Option<DrawConfig>,
     pub seed: Option<i64>,
+    /// The revision this one was hand-edited from, if it was.
+    pub adjusted_from: Option<i32>,
+    /// What that edit was, in words.
+    pub adjustment_note: Option<String>,
+}
+
+/// Keeps only the live draw for each pool and year.
+///
+/// Expects the newest revision of each to come first, which is how
+/// `load_exchanges` orders them.
+pub fn only_current_revisions(exchanges: Vec<Exchange>) -> Vec<Exchange> {
+    let mut seen = std::collections::HashSet::new();
+    exchanges
+        .into_iter()
+        .filter(|e| seen.insert((e.pool_id, e.year)))
+        .collect()
+}
+
+/// What a proposed swap would do, as shown before it is applied.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SwapPreview {
+    pub exchange_id: i32,
+    pub a: String,
+    pub b: String,
+    /// Only the pairings that move.
+    pub changes: Vec<SwapChange>,
+    /// Rules the swap would break. Not a refusal — see [`SwapViolation`].
+    pub violations: Vec<SwapViolation>,
 }
 
 impl Exchange {
+    /// Whether this draw was adjusted by hand rather than produced by the solver.
+    ///
+    /// The consequence that matters: a hand-edited draw cannot be replayed from
+    /// its seed, so it carries none.
+    pub fn was_adjusted(&self) -> bool {
+        self.adjusted_from.is_some()
+    }
+
     /// The permutation split into cycles, for visualization.
     pub fn cycles(&self) -> Vec<Vec<String>> {
         let next: std::collections::HashMap<&str, &str> = self
@@ -226,6 +262,8 @@ mod tests {
             ],
             config: None,
             seed: None,
+            adjusted_from: None,
+            adjustment_note: None,
         };
 
         let cycles = exchange.cycles();
@@ -258,6 +296,8 @@ mod tests {
             exclusions: vec![],
             config: None,
             seed: None,
+            adjusted_from: None,
+            adjustment_note: None,
         };
 
         let cycles = exchange.cycles();

--- a/christmas/src/pages/admin.rs
+++ b/christmas/src/pages/admin.rs
@@ -5,7 +5,8 @@ use crate::{
     app::Route,
     auth::Role,
     components::{
-        BackfillSection, DrawSection, LettersSection, ParticipantsSection, PoolsSection, RelationshipsSection,
+        AdjustSection, BackfillSection, DrawSection, LettersSection, ParticipantsSection, PoolsSection,
+        RelationshipsSection,
     },
     server,
 };
@@ -121,6 +122,12 @@ fn ManageBody() -> Element {
             pools: pool_list.clone(),
             exchanges: exchange_list.clone(),
             year: current_year(),
+            on_change: reload_all,
+        }
+
+        AdjustSection {
+            pools: pool_list.clone(),
+            exchanges: exchange_list.clone(),
             on_change: reload_all,
         }
 

--- a/christmas/src/pages/pool.rs
+++ b/christmas/src/pages/pool.rs
@@ -171,7 +171,7 @@ fn PoolBody(detail: PoolDetail) -> Element {
                     }
                 }
 
-                DrawSettings { draw: draw.clone() }
+                DrawSettings { draw: draw.clone(), is_manager }
             },
             _ => rsx! {
                 div { class: "empty-cta",
@@ -227,32 +227,87 @@ fn PoolBody(detail: PoolDetail) -> Element {
     }
 }
 
-/// Shows the rules the draw ran under, so a result can be explained later.
-#[component]
-fn DrawSettings(draw: Exchange) -> Element {
-    let Some(config) = draw.config.as_ref() else {
-        return rsx! {};
-    };
+/// Drops the leading capital so a stored note reads as part of a sentence.
+///
+/// Only the first character: the notes carry people's names, and lowercasing the
+/// whole thing turns "Swapped Alec and Noel" into "swapped alec and noel".
+fn uncapitalize(note: &str) -> String {
+    let mut chars = note.chars();
+    chars.next().map_or_else(String::new, |first| {
+        first.to_lowercase().collect::<String>() + chars.as_str()
+    })
+}
 
-    let mode = match config.cycle_mode {
-        crate::model::CycleMode::Grand => "one grand ring".to_string(),
-        crate::model::CycleMode::Multiple { min_len } => format!("multiple rings, at least {min_len} each"),
-    };
-    let spouses = if config.exclude_spouses {
-        "spouses kept apart"
-    } else {
-        "spouses allowed"
-    };
-    let repeats = match config.avoid_repeat_years {
-        Some(1) => "no repeat of last year's receiver".to_string(),
-        Some(n) => format!("no repeat from the last {n} years"),
-        None => "repeats allowed".to_string(),
-    };
+/// Shows the rules the draw ran under, so a result can be explained later.
+///
+/// A hand-adjusted draw says so. The panel's whole job is to explain where the
+/// result came from, and staying quiet about an edit would make it assert
+/// something untrue. What the edit *was* stays with the managers, for the same
+/// reason the revision badge does.
+#[component]
+fn DrawSettings(draw: Exchange, is_manager: bool) -> Element {
+    let rules = draw.config.as_ref().map(|config| {
+        let mode = match config.cycle_mode {
+            crate::model::CycleMode::Grand => "one grand ring".to_string(),
+            crate::model::CycleMode::Multiple { min_len } => format!("multiple rings, at least {min_len} each"),
+        };
+        let spouses = if config.exclude_spouses {
+            "spouses kept apart"
+        } else {
+            "spouses allowed"
+        };
+        let repeats = match config.avoid_repeat_years {
+            Some(1) => "no repeat of last year's receiver".to_string(),
+            Some(n) => format!("no repeat from the last {n} years"),
+            None => "repeats allowed".to_string(),
+        };
+        format!("{mode} · {spouses} · {repeats}")
+    });
+
+    // Nothing recorded and nothing edited: there is genuinely nothing to say.
+    if rules.is_none() && !draw.was_adjusted() {
+        return rsx! {};
+    }
 
     rsx! {
         section { class: "section",
             div { class: "section-head", h2 { "How it was drawn" } }
-            div { class: "notice", "{mode} · {spouses} · {repeats}" }
+            div { class: "notice",
+                if let Some(rules) = rules {
+                    "{rules}"
+                }
+                if draw.was_adjusted() {
+                    div { style: "margin-top: 0.4rem",
+                        "Adjusted by hand afterwards"
+                        if is_manager {
+                            if let Some(note) = draw.adjustment_note.as_deref() {
+                                " — {uncapitalize(note)}"
+                            }
+                        }
+                        "."
+                    }
+                }
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The names inside a note must survive being folded into a sentence.
+    #[test]
+    fn uncapitalize_only_touches_the_first_letter() {
+        assert_eq!(uncapitalize("Swapped Alec and Noel"), "swapped Alec and Noel");
+        assert_eq!(uncapitalize("Swapped K-Lee and Meaghann"), "swapped K-Lee and Meaghann");
+    }
+
+    #[test]
+    fn uncapitalize_handles_the_awkward_cases() {
+        assert_eq!(uncapitalize(""), "");
+        assert_eq!(uncapitalize("already lower"), "already lower");
+        // Not every alphabet has a lowercase form; it must not panic or truncate.
+        assert_eq!(uncapitalize("字 and Anne"), "字 and Anne");
     }
 }

--- a/christmas/src/server/draw.rs
+++ b/christmas/src/server/draw.rs
@@ -1,8 +1,10 @@
 use dioxus::prelude::*;
 
+#[cfg(feature = "server")]
+use crate::model::only_current_revisions;
 // Only the types in the public signatures are imported here; the rest are
 // pulled in inside the server-gated bodies so the wasm build stays clean.
-use crate::model::{DrawConfig, Exchange};
+use crate::model::{DrawConfig, Exchange, SwapPreview};
 
 #[cfg(feature = "server")]
 #[derive(sqlx::FromRow)]
@@ -19,6 +21,8 @@ struct ExchangeRow {
     pairings: sqlx::types::Json<Vec<crate::model::Pairing>>,
     config: sqlx::types::Json<serde_json::Value>,
     seed: Option<i64>,
+    adjusted_from: Option<i32>,
+    adjustment_note: Option<String>,
 }
 
 #[cfg(feature = "server")]
@@ -49,7 +53,8 @@ pub(crate) async fn load_exchanges(db: &sqlx::PgPool, pool_id: Option<i32>) -> R
     let sql = r"
         SELECT e.id, e.pool_id, p.name AS pool_name, p.slug AS pool_slug,
                e.year, e.revision, e.letter,
-               e.participants, e.exclusions, e.pairings, e.config, e.seed
+               e.participants, e.exclusions, e.pairings, e.config, e.seed,
+               e.adjusted_from, e.adjustment_note
         FROM exchange e
         JOIN pool p ON p.id = e.pool_id
         WHERE ($1::int IS NULL OR e.pool_id = $1)
@@ -78,21 +83,10 @@ pub(crate) async fn load_exchanges(db: &sqlx::PgPool, pool_id: Option<i32>) -> R
             // Rows written before migration 003 carry `{}`; tolerate that.
             config: serde_json::from_value(r.config.0).ok(),
             seed: r.seed,
+            adjusted_from: r.adjusted_from,
+            adjustment_note: r.adjustment_note,
         })
         .collect())
-}
-
-/// Keeps only the live draw for each pool and year.
-///
-/// Rows arrive ordered by year then revision descending, so the first sighting
-/// of a (pool, year) is the current one.
-#[cfg(feature = "server")]
-pub(crate) fn only_current_revisions(exchanges: Vec<Exchange>) -> Vec<Exchange> {
-    let mut seen = std::collections::HashSet::new();
-    exchanges
-        .into_iter()
-        .filter(|e| seen.insert((e.pool_id, e.year)))
-        .collect()
 }
 
 /// Superseded revisions are dropped for anyone but a manager — filtered here
@@ -376,6 +370,8 @@ pub async fn run_draw(
         pairings,
         config: Some(config),
         seed: Some(seed_i64),
+        adjusted_from: None,
+        adjustment_note: None,
     })
 }
 
@@ -528,6 +524,179 @@ pub async fn record_past_draw(
         pairings,
         config: None,
         seed: None,
+        adjusted_from: None,
+        adjustment_note: None,
+    })
+}
+
+/// The rules a swap is judged against.
+///
+/// Taken from the config the draw ran under, but evaluated against the *current*
+/// relationships rather than the archived snapshot. If somebody married since
+/// December, that is exactly the sort of thing a hand adjustment is for, and the
+/// warning should reflect who they are now. A backfilled year has no config, so
+/// it falls back to the family's usual rules.
+#[cfg(feature = "server")]
+async fn swap_rules(
+    db: &sqlx::PgPool,
+    exchange: &Exchange,
+) -> Result<Vec<crate::matching::BlockedEdge>, ServerFnError> {
+    let config = exchange.config.clone().unwrap_or_default();
+    let (mut blocked, _) = relationship_edges(db, config.exclude_spouses).await?;
+    if let Some(lookback) = config.avoid_repeat_years {
+        blocked.extend(repeat_edges(db, exchange.pool_id, exchange.year, lookback).await?);
+    }
+    Ok(blocked)
+}
+
+/// Loads a draw that is eligible to be adjusted.
+///
+/// Only the live revision qualifies. Editing a superseded one would fork the
+/// history into two competing lines for the same year, and the revision counter
+/// has no way to express that.
+#[cfg(feature = "server")]
+async fn adjustable(db: &sqlx::PgPool, exchange_id: i32) -> Result<Exchange, ServerFnError> {
+    let all = load_exchanges(db, None).await?;
+
+    let Some(target) = all.iter().find(|e| e.id == exchange_id).cloned() else {
+        return Err(ServerFnError::new(format!("No draw with id {exchange_id}")));
+    };
+
+    let live = only_current_revisions(all).into_iter().any(|e| e.id == exchange_id);
+    if !live {
+        return Err(ServerFnError::new(format!(
+            "Revision {} is not the current draw for {}. Adjust the latest one instead.",
+            target.revision, target.year
+        )));
+    }
+
+    Ok(target)
+}
+
+/// Works out what swapping two people would do, without changing anything.
+///
+/// Separate from [`apply_swap`] so the change can be shown and confirmed first —
+/// a swap moves up to four pairings, not the two the name suggests, and that is
+/// worth seeing before it is saved.
+#[server]
+pub async fn preview_swap(exchange_id: i32, a: String, b: String) -> Result<SwapPreview, ServerFnError> {
+    let db = crate::pool().await?;
+    let exchange = adjustable(db, exchange_id).await?;
+    let blocked = swap_rules(db, &exchange).await?;
+
+    let current: Vec<(String, String)> = exchange
+        .pairings
+        .iter()
+        .map(|p| (p.giver.clone(), p.receiver.clone()))
+        .collect();
+
+    let swap =
+        crate::matching::swap_in_ring(&current, &a, &b, &blocked).map_err(|e| ServerFnError::new(e.to_string()))?;
+
+    Ok(SwapPreview {
+        exchange_id,
+        a,
+        b,
+        changes: swap.changes,
+        violations: swap.violations,
+    })
+}
+
+/// Swaps two people's places in their ring, recording the result as a new revision.
+///
+/// Recomputed here rather than trusting whatever the preview showed, so the saved
+/// pairings are always the ones these two names actually produce.
+///
+/// `despite_warnings` is the caller's acknowledgement that the swap breaks one of
+/// the draw's rules. Without it, a swap that would pair spouses is refused — that
+/// is nearly always a slip rather than an intention.
+#[server]
+pub async fn apply_swap(
+    exchange_id: i32,
+    a: String,
+    b: String,
+    despite_warnings: bool,
+) -> Result<Exchange, ServerFnError> {
+    use sqlx::types::Json;
+
+    use crate::model::Pairing;
+
+    let db = crate::pool().await?;
+    let exchange = adjustable(db, exchange_id).await?;
+    let blocked = swap_rules(db, &exchange).await?;
+
+    let current: Vec<(String, String)> = exchange
+        .pairings
+        .iter()
+        .map(|p| (p.giver.clone(), p.receiver.clone()))
+        .collect();
+
+    let swap =
+        crate::matching::swap_in_ring(&current, &a, &b, &blocked).map_err(|e| ServerFnError::new(e.to_string()))?;
+
+    if !swap.violations.is_empty() && !despite_warnings {
+        let detail = swap
+            .violations
+            .iter()
+            .map(|v| format!("{} would give to {} ({})", v.giver, v.receiver, v.reason))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(ServerFnError::new(format!(
+            "That swap breaks the draw's rules: {detail}. Tick the box to do it anyway."
+        )));
+    }
+
+    let pairings: Vec<Pairing> = swap
+        .pairings
+        .into_iter()
+        .map(|(giver, receiver)| Pairing { giver, receiver })
+        .collect();
+
+    let note = format!("Swapped {a} and {b}");
+
+    // The seed is deliberately dropped. It no longer reproduces these pairings,
+    // and a seed that replays as something else is worse than none at all. The
+    // config stays, because the rules it describes are still the rules this draw
+    // was made under.
+    let row: (i32, i32) = sqlx::query_as(
+        r"INSERT INTO exchange (pool_id, year, revision, letter, participants, exclusions, pairings, config,
+                                seed, adjusted_from, adjustment_note)
+          VALUES ($1, $2,
+                  (SELECT COALESCE(MAX(revision), 0) + 1 FROM exchange WHERE pool_id = $1 AND year = $2),
+                  $3, $4, $5, $6, $7, NULL, $8, $9)
+          RETURNING id, revision",
+    )
+    .bind(exchange.pool_id)
+    .bind(exchange.year)
+    .bind(exchange.letter.map(|c| c.to_string()))
+    .bind(Json(&exchange.participants))
+    .bind(Json(&exchange.exclusions))
+    .bind(Json(&pairings))
+    .bind(Json(&exchange.config))
+    .bind(exchange_id)
+    .bind(&note)
+    .fetch_one(db)
+    .await
+    .map_err(super::db_err)?;
+
+    tracingx::info!(
+        pool = %exchange.pool_name,
+        year = exchange.year,
+        revision = row.1,
+        adjusted_from = exchange_id,
+        moved = swap.changes.len(),
+        overrode_warnings = !swap.violations.is_empty(),
+        "draw adjusted by hand"
+    );
+
+    Ok(Exchange {
+        id: row.0,
+        revision: row.1,
+        pairings,
+        seed: None,
+        adjusted_from: Some(exchange_id),
+        adjustment_note: Some(note),
+        ..exchange
     })
 }
 
@@ -550,6 +719,8 @@ mod tests {
             pairings: vec![],
             config: None,
             seed: None,
+            adjusted_from: None,
+            adjustment_note: None,
         }
     }
 

--- a/christmas/src/server/mod.rs
+++ b/christmas/src/server/mod.rs
@@ -7,7 +7,7 @@ mod pools;
 mod relationships;
 mod session;
 
-pub use draw::{exchange_detail, list_exchanges, list_year, record_past_draw, run_draw};
+pub use draw::{apply_swap, exchange_detail, list_exchanges, list_year, preview_swap, record_past_draw, run_draw};
 pub use letters::{list_all_excluded_letters, list_excluded_letters, set_excluded_letters};
 pub use participants::{add_participant, list_participants, remove_participant};
 pub use pools::{add_member, create_pool, delete_pool, list_memberships, list_pools, pool_detail, remove_member};

--- a/christmas/src/server/pools.rs
+++ b/christmas/src/server/pools.rs
@@ -178,7 +178,7 @@ pub async fn pool_detail(slug: String) -> Result<PoolDetail, ServerFnError> {
     let exchanges = if crate::auth::caller_role().await == crate::auth::Role::Manager {
         all
     } else {
-        super::draw::only_current_revisions(all)
+        crate::model::only_current_revisions(all)
     };
 
     Ok(PoolDetail {

--- a/christmas/tests/draw_integration.rs
+++ b/christmas/tests/draw_integration.rs
@@ -279,3 +279,144 @@ fn a_pool_that_cannot_draw_reports_why() {
         );
     });
 }
+
+#[test]
+#[ignore = "needs a database"]
+fn a_swap_is_recorded_as_a_new_revision() {
+    rt().block_on(async {
+        reset().await;
+        let pool_id = pool_id_for("grabergishimazureson").await;
+
+        let original = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("draw");
+
+        // Two people who are not each other's giver or receiver, so the swap is
+        // the four-edge case rather than the adjacent three-edge one.
+        let ring = original.cycles().into_iter().next().expect("one grand ring");
+        let (a, b) = (ring[0].clone(), ring[5].clone());
+
+        let preview = server::preview_swap(original.id, a.clone(), b.clone())
+            .await
+            .expect("preview");
+        assert_eq!(preview.changes.len(), 4, "a non-adjacent swap moves four pairings");
+
+        let adjusted = server::apply_swap(original.id, a.clone(), b.clone(), false)
+            .await
+            .expect("swap should apply");
+
+        assert_eq!(adjusted.revision, original.revision + 1);
+        assert_ne!(adjusted.id, original.id, "the original draw must survive");
+        assert_eq!(adjusted.adjusted_from, Some(original.id));
+        assert_eq!(
+            adjusted.adjustment_note.as_deref(),
+            Some(format!("Swapped {a} and {b}").as_str())
+        );
+        assert!(adjusted.was_adjusted());
+
+        // A hand-edited draw cannot be replayed, so it carries no seed.
+        assert!(adjusted.seed.is_none(), "an adjusted draw must not claim a seed");
+        assert!(adjusted.config.is_some(), "the rules it ran under still apply");
+
+        // Everyone still gives and receives exactly once, in one ring.
+        assert_eq!(adjusted.pairings.len(), 14);
+        assert_eq!(adjusted.cycles().len(), 1);
+        assert_eq!(adjusted.letter, original.letter);
+        assert_eq!(adjusted.participants, original.participants);
+
+        // The two named people really did trade places.
+        let receiver_of = |draw: &christmas::model::Exchange, giver: &str| {
+            draw.pairings
+                .iter()
+                .find(|p| p.giver == giver)
+                .map(|p| p.receiver.clone())
+                .expect("every giver has a receiver")
+        };
+        let giver_to = |draw: &christmas::model::Exchange, receiver: &str| {
+            draw.pairings
+                .iter()
+                .find(|p| p.receiver == receiver)
+                .map(|p| p.giver.clone())
+                .expect("everyone receives")
+        };
+        assert_eq!(receiver_of(&adjusted, &a), receiver_of(&original, &b));
+        assert_eq!(receiver_of(&adjusted, &b), receiver_of(&original, &a));
+        assert_eq!(giver_to(&adjusted, &a), giver_to(&original, &b));
+        assert_eq!(giver_to(&adjusted, &b), giver_to(&original, &a));
+
+        // The live draw for the year is now the adjusted one.
+        let current = server::list_year(2026).await.expect("year");
+        let live = current.iter().find(|e| e.pool_id == pool_id).expect("a live draw");
+        assert_eq!(live.id, adjusted.id);
+    });
+}
+
+#[test]
+#[ignore = "needs a database"]
+fn a_swap_that_pairs_spouses_needs_confirming() {
+    rt().block_on(async {
+        reset().await;
+        let pool_id = pool_id_for("grabergishimazureson").await;
+
+        let draw = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("draw");
+
+        // Claire and Duncan are married. Putting Duncan where Claire's receiver
+        // is makes Claire give to him, which the draw forbade.
+        let claire_gives_to = draw
+            .pairings
+            .iter()
+            .find(|p| p.giver == "Claire")
+            .expect("Claire is in the pool")
+            .receiver
+            .clone();
+
+        let preview = server::preview_swap(draw.id, claire_gives_to.clone(), "Duncan".to_string())
+            .await
+            .expect("preview");
+        assert!(
+            preview
+                .violations
+                .iter()
+                .any(|v| v.giver == "Claire" && v.receiver == "Duncan"),
+            "the spouse rule should be flagged: {:?}",
+            preview.violations
+        );
+
+        let refused = server::apply_swap(draw.id, claire_gives_to.clone(), "Duncan".to_string(), false).await;
+        assert!(refused.is_err(), "an unconfirmed rule-breaking swap must be refused");
+
+        let forced = server::apply_swap(draw.id, claire_gives_to, "Duncan".to_string(), true)
+            .await
+            .expect("confirming should let it through");
+        assert_eq!(forced.revision, 2);
+    });
+}
+
+#[test]
+#[ignore = "needs a database"]
+fn only_the_live_revision_can_be_adjusted() {
+    rt().block_on(async {
+        reset().await;
+        let pool_id = pool_id_for("pets").await;
+
+        let first = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("first draw");
+        let second = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("second draw");
+
+        let ring = second.cycles().into_iter().next().expect("one ring");
+        let (a, b) = (ring[0].clone(), ring[2].clone());
+
+        // Adjusting the superseded revision would fork the year's history.
+        let stale = server::apply_swap(first.id, a.clone(), b.clone(), false).await;
+        assert!(stale.is_err(), "a superseded revision must not be adjustable");
+
+        server::apply_swap(second.id, a, b, false)
+            .await
+            .expect("the live revision adjusts fine");
+    });
+}


### PR DESCRIPTION
Managers can now swap two people's places in a draw without re-running the solver.

When the draw is right but life isn't — somebody moved, somebody is unwell, somebody already bought the wrong present — re-running the whole thing throws away thirteen good pairings to fix one. The new adjust panel on the manage page lets a manager pick any two people from the same ring and trade their positions. Everyone else keeps who they have.

The swap is previewed before it is saved. Because trading two positions moves up to four edges (not two), the preview table shows every pairing that would change. If the swap would break a rule the draw ran under — pairing spouses, repeating a recent year — those violations are listed and a confirmation checkbox is required before the apply button becomes active.

The result is saved as a new revision, leaving the original intact. The seed is dropped from the new record, since it no longer reproduces the pairings, but the draw config is kept so the rules it ran under remain on the record. The pool page's "How it was drawn" section notes when a draw was adjusted by hand, and managers see the note describing what the edit was.

Two new columns on the `exchange` table (`adjusted_from` and `adjustment_note`) distinguish hand-edited revisions from solver output. The `only_current_revisions` helper has moved from the server module into the model, where both the server and the client component can use it.