### PR TITLE
[christmas] restore an earlier revision from the manage page

### DIFF
--- a/christmas/README.md
+++ b/christmas/README.md
@@ -56,6 +56,18 @@ drawn" line is omitted for those years instead of claiming something untrue.
 Backfilling uses the same revision counter as a draw, so it never overwrites an
 existing year — recording 2019 twice leaves two revisions, the newer one live.
 
+## Restoring an earlier revision
+
+Because every draw, re-draw and hand adjustment is kept, the way back from a
+change you regret is already on the record. **Manage → Revision history** lists
+each year that has more than one revision and restores any of them.
+
+A restore writes the old pairings again as the next revision rather than
+deleting or renumbering anything, so "which draw is live" stays the one question
+of which revision is highest, and a restore is itself undone by restoring
+whatever it replaced. The seed comes along — unlike a swap, these really are the
+pairings that seed produced, so it still replays them.
+
 ## Running it
 
 Needs a PostgreSQL. The workspace's `docker-local-monitoring/docker-compose.yml`

--- a/christmas/src/auth.rs
+++ b/christmas/src/auth.rs
@@ -410,6 +410,7 @@ mod tests {
             "/api/record_past_draw1",
             "/api/preview_swap1",
             "/api/apply_swap1",
+            "/api/restore_revision1",
             "/api/create_pool1",
             "/api/delete_pool1",
             "/api/add_participant1",

--- a/christmas/src/components/mod.rs
+++ b/christmas/src/components/mod.rs
@@ -7,6 +7,7 @@ mod letters;
 mod participants;
 mod pools;
 mod relationships;
+mod revisions;
 
 pub use adjust::AdjustSection;
 pub use backfill::BackfillSection;
@@ -17,3 +18,4 @@ pub use letters::LettersSection;
 pub use participants::ParticipantsSection;
 pub use pools::PoolsSection;
 pub use relationships::RelationshipsSection;
+pub use revisions::RevisionsSection;

--- a/christmas/src/components/revisions.rs
+++ b/christmas/src/components/revisions.rs
@@ -1,0 +1,204 @@
+//! Going back to an earlier revision of a draw.
+//!
+//! Every draw, re-draw and hand adjustment is kept, so the record already holds
+//! the answer when a change turns out to have been a mistake. This is the way
+//! back to it: pick the revision that was right and make it the live one again.
+
+use dioxus::prelude::*;
+
+use crate::{
+    model::{Exchange, RevisionHistory, revision_histories},
+    server,
+};
+
+/// The revision history of every year that has one, with a way back.
+///
+/// Draws are passed in rather than fetched: a `use_resource` whose only input is
+/// a component prop registers no reactive dependency, so it would never re-run
+/// once the list loaded — the same trap documented in `letters.rs`.
+#[component]
+pub fn RevisionsSection(exchanges: Vec<Exchange>, on_change: EventHandler<()>) -> Element {
+    // A year drawn once has nothing to go back to, and listing it would bury the
+    // years that do.
+    let histories: Vec<RevisionHistory> = revision_histories(exchanges)
+        .into_iter()
+        .filter(|h| h.revisions.len() > 1)
+        .collect();
+
+    // Which row is in flight, so only its button says so.
+    let mut restoring = use_signal(|| None::<i32>);
+    let mut error = use_signal(|| None::<String>);
+    let mut restored = use_signal(|| None::<Exchange>);
+
+    let mut restore = move |id: i32| {
+        restoring.set(Some(id));
+        error.set(None);
+        restored.set(None);
+        spawn(async move {
+            match server::restore_revision(id).await {
+                Ok(exchange) => {
+                    restored.set(Some(exchange));
+                    on_change.call(());
+                }
+                Err(e) => error.set(Some(e.to_string())),
+            }
+            restoring.set(None);
+        });
+    };
+
+    rsx! {
+        div { class: "panel",
+            h3 { "Revision history" }
+            p { class: "muted", style: "font-size: 0.85rem; margin-top: -0.5rem",
+                "Restoring puts an earlier revision back in charge by recording it again as the newest one. Nothing is overwritten, so a restore can itself be undone."
+            }
+
+            if let Some(e) = error() {
+                div { class: "error-box", "{e}" }
+            }
+
+            if let Some(exchange) = restored() {
+                div { class: "notice",
+                    "{exchange.pool_name} {exchange.year} is back to those pairings, saved as revision {exchange.revision}."
+                }
+            }
+
+            if histories.is_empty() {
+                p { class: "muted", "No year has been drawn more than once yet." }
+            } else {
+                for history in histories.iter() {
+                    div { key: "{history.pool_id}-{history.year}", style: "margin-top: 1.25rem",
+                        div { class: "section-head",
+                            h2 { style: "font-size: 1.05rem", "{history.pool_name} · {history.year}" }
+                            span { class: "count", "{history.revisions.len()} revisions" }
+                        }
+                        div { class: "table-scroll",
+                            table { class: "data-table",
+                                thead {
+                                    tr {
+                                        th { "Revision" }
+                                        th { "What it was" }
+                                        th { "Letter" }
+                                        th { "People" }
+                                        th { "Rings" }
+                                        th { "" }
+                                    }
+                                }
+                                tbody {
+                                    for (position , exchange) in history.revisions.iter().enumerate() {
+                                        {
+                                            // Sorted highest revision first, so the head is live.
+                                            let is_live = position == 0;
+                                            let id = exchange.id;
+                                            rsx! {
+                                                tr { key: "{id}",
+                                                    td { class: "mono", "{exchange.revision}" }
+                                                    td { "{provenance(exchange)}" }
+                                                    td { {exchange.letter.map_or_else(|| "—".to_string(), |c| c.to_string())} }
+                                                    td { class: "mono", "{exchange.participants.len()}" }
+                                                    td { class: "mono", "{exchange.cycles().len()}" }
+                                                    td {
+                                                        if is_live {
+                                                            span { class: "badge current", "current" }
+                                                        } else {
+                                                            button {
+                                                                class: "ghost",
+                                                                style: "padding: 0.25rem 0.6rem; font-size: 0.85rem",
+                                                                disabled: restoring().is_some(),
+                                                                onclick: move |_| restore(id),
+                                                                if restoring() == Some(id) {
+                                                                    "Restoring…"
+                                                                } else {
+                                                                    "Restore"
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Where a revision came from, in a few words.
+///
+/// A hand edit already describes itself. Everything else is told apart by
+/// whether the draw was recorded with the rules it ran under: the solver always
+/// writes them, and a backfilled year deliberately does not, because nobody
+/// knows what rules a paper draw from 2014 followed.
+fn provenance(exchange: &Exchange) -> String {
+    exchange.adjustment_note.clone().unwrap_or_else(|| {
+        if exchange.config.is_some() {
+            "Drawn".to_string()
+        } else {
+            "Entered by hand".to_string()
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::DrawConfig;
+
+    fn exchange(revision: i32) -> Exchange {
+        Exchange {
+            id: revision,
+            pool_id: 1,
+            pool_name: "Pets".into(),
+            pool_slug: "pets".into(),
+            year: 2026,
+            revision,
+            letter: None,
+            participants: vec![],
+            exclusions: vec![],
+            pairings: vec![],
+            config: None,
+            seed: None,
+            adjusted_from: None,
+            adjustment_note: None,
+        }
+    }
+
+    #[test]
+    fn a_solver_draw_says_so() {
+        let drawn = Exchange {
+            config: Some(DrawConfig::default()),
+            ..exchange(1)
+        };
+        assert_eq!(provenance(&drawn), "Drawn");
+    }
+
+    /// A backfill carries no config precisely because its rules are unknown.
+    #[test]
+    fn a_backfilled_year_is_not_passed_off_as_a_draw() {
+        assert_eq!(provenance(&exchange(1)), "Entered by hand");
+    }
+
+    /// Including a restore, whose note is what makes the trail readable.
+    #[test]
+    fn an_edited_revision_speaks_for_itself() {
+        let adjusted = Exchange {
+            config: Some(DrawConfig::default()),
+            adjusted_from: Some(1),
+            adjustment_note: Some("Swapped Alec and Noel".into()),
+            ..exchange(2)
+        };
+        assert_eq!(provenance(&adjusted), "Swapped Alec and Noel");
+
+        let restored = Exchange {
+            adjusted_from: Some(1),
+            adjustment_note: Some("Restored revision 1".into()),
+            ..exchange(3)
+        };
+        assert_eq!(provenance(&restored), "Restored revision 1");
+    }
+}

--- a/christmas/src/model.rs
+++ b/christmas/src/model.rs
@@ -118,6 +118,48 @@ pub fn only_current_revisions(exchanges: Vec<Exchange>) -> Vec<Exchange> {
         .collect()
 }
 
+/// Every revision of one pool's draw for one year.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RevisionHistory {
+    pub pool_id: i32,
+    pub pool_name: String,
+    pub year: i32,
+    /// Highest revision first, so the head is the live draw.
+    pub revisions: Vec<Exchange>,
+}
+
+/// Groups draws by pool and year, so a year's revisions can be shown together.
+///
+/// Groups come out in the order the pools and years were first seen, which for
+/// `load_exchanges` means newest year first. Revisions inside a group are sorted
+/// here rather than assumed, so the head is the live draw whatever order the
+/// caller had them in.
+pub fn revision_histories(exchanges: Vec<Exchange>) -> Vec<RevisionHistory> {
+    let mut groups: Vec<RevisionHistory> = Vec::new();
+
+    for exchange in exchanges {
+        if let Some(group) = groups
+            .iter_mut()
+            .find(|g| g.pool_id == exchange.pool_id && g.year == exchange.year)
+        {
+            group.revisions.push(exchange);
+        } else {
+            groups.push(RevisionHistory {
+                pool_id: exchange.pool_id,
+                pool_name: exchange.pool_name.clone(),
+                year: exchange.year,
+                revisions: vec![exchange],
+            });
+        }
+    }
+
+    for group in &mut groups {
+        group.revisions.sort_by_key(|e| std::cmp::Reverse(e.revision));
+    }
+
+    groups
+}
+
 /// What a proposed swap would do, as shown before it is applied.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SwapPreview {
@@ -131,10 +173,12 @@ pub struct SwapPreview {
 }
 
 impl Exchange {
-    /// Whether this draw was adjusted by hand rather than produced by the solver.
+    /// Whether a manager stepped in after the solver — a swap, or an earlier
+    /// revision put back in charge.
     ///
-    /// The consequence that matters: a hand-edited draw cannot be replayed from
-    /// its seed, so it carries none.
+    /// The two differ in one consequence: a swap moves pairings the seed no
+    /// longer produces, so it carries none, while a restore brings back pairings
+    /// its seed still replays.
     pub fn was_adjusted(&self) -> bool {
         self.adjusted_from.is_some()
     }
@@ -303,5 +347,64 @@ mod tests {
         let cycles = exchange.cycles();
         assert_eq!(cycles.len(), 1);
         assert_eq!(cycles[0], vec!["A", "B", "C"]);
+    }
+
+    fn revision_of(pool_id: i32, year: i32, revision: i32) -> Exchange {
+        Exchange {
+            id: pool_id * 1000 + year * 10 + revision,
+            pool_id,
+            pool_name: format!("Pool {pool_id}"),
+            pool_slug: format!("pool-{pool_id}"),
+            year,
+            revision,
+            letter: None,
+            participants: vec![],
+            exclusions: vec![],
+            pairings: vec![],
+            config: None,
+            seed: None,
+            adjusted_from: None,
+            adjustment_note: None,
+        }
+    }
+
+    #[test]
+    fn revisions_are_grouped_by_pool_and_year() {
+        // As the query returns them: year then revision, both descending, with
+        // two pools interleaved within a year.
+        let rows = vec![
+            revision_of(1, 2026, 3),
+            revision_of(1, 2026, 2),
+            revision_of(2, 2026, 1),
+            revision_of(1, 2026, 1),
+            revision_of(1, 2025, 1),
+        ];
+
+        let histories = revision_histories(rows);
+        let shape: Vec<(i32, i32, usize)> = histories
+            .iter()
+            .map(|h| (h.pool_id, h.year, h.revisions.len()))
+            .collect();
+        assert_eq!(shape, vec![(1, 2026, 3), (2, 2026, 1), (1, 2025, 1)]);
+    }
+
+    /// The head of each group is what the restore UI marks as current, so it has
+    /// to be the live revision however the rows arrived.
+    #[test]
+    fn the_newest_revision_leads_its_group() {
+        let rows = vec![
+            revision_of(1, 2026, 1),
+            revision_of(1, 2026, 3),
+            revision_of(1, 2026, 2),
+        ];
+
+        let histories = revision_histories(rows);
+        let revisions: Vec<i32> = histories[0].revisions.iter().map(|e| e.revision).collect();
+        assert_eq!(revisions, vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn nothing_drawn_means_nothing_to_group() {
+        assert!(revision_histories(vec![]).is_empty());
     }
 }

--- a/christmas/src/pages/admin.rs
+++ b/christmas/src/pages/admin.rs
@@ -6,7 +6,7 @@ use crate::{
     auth::Role,
     components::{
         AdjustSection, BackfillSection, DrawSection, LettersSection, ParticipantsSection, PoolsSection,
-        RelationshipsSection,
+        RelationshipsSection, RevisionsSection,
     },
     server,
 };
@@ -130,6 +130,8 @@ fn ManageBody() -> Element {
             exchanges: exchange_list.clone(),
             on_change: reload_all,
         }
+
+        RevisionsSection { exchanges: exchange_list.clone(), on_change: reload_all }
 
         BackfillSection {
             pools: pool_list.clone(),

--- a/christmas/src/server/draw.rs
+++ b/christmas/src/server/draw.rs
@@ -700,6 +700,76 @@ pub async fn apply_swap(
     })
 }
 
+/// Puts an earlier revision back in charge.
+///
+/// Nothing is deleted and nothing is renumbered: the old pairings are written
+/// again as the next revision. "Which draw is live" stays the one question of
+/// which revision is highest, and the revisions being stepped back over are
+/// still on the record — including this restore, which is itself undone by
+/// restoring whatever it replaced.
+///
+/// Unlike a swap, the seed comes along. These are the pairings it produced, so
+/// it still replays them.
+#[server]
+pub async fn restore_revision(exchange_id: i32) -> Result<Exchange, ServerFnError> {
+    use sqlx::types::Json;
+
+    let db = crate::pool().await?;
+    let all = load_exchanges(db, None).await?;
+
+    let Some(target) = all.iter().find(|e| e.id == exchange_id).cloned() else {
+        return Err(ServerFnError::new(format!("No draw with id {exchange_id}")));
+    };
+
+    if only_current_revisions(all).iter().any(|e| e.id == exchange_id) {
+        return Err(ServerFnError::new(format!(
+            "Revision {} is already the current draw for {}.",
+            target.revision, target.year
+        )));
+    }
+
+    let note = format!("Restored revision {}", target.revision);
+
+    let row: (i32, i32) = sqlx::query_as(
+        r"INSERT INTO exchange (pool_id, year, revision, letter, participants, exclusions, pairings, config,
+                                seed, adjusted_from, adjustment_note)
+          VALUES ($1, $2,
+                  (SELECT COALESCE(MAX(revision), 0) + 1 FROM exchange WHERE pool_id = $1 AND year = $2),
+                  $3, $4, $5, $6, $7, $8, $9, $10)
+          RETURNING id, revision",
+    )
+    .bind(target.pool_id)
+    .bind(target.year)
+    .bind(target.letter.map(|c| c.to_string()))
+    .bind(Json(&target.participants))
+    .bind(Json(&target.exclusions))
+    .bind(Json(&target.pairings))
+    .bind(Json(&target.config))
+    .bind(target.seed)
+    .bind(exchange_id)
+    .bind(&note)
+    .fetch_one(db)
+    .await
+    .map_err(super::db_err)?;
+
+    tracingx::info!(
+        pool = %target.pool_name,
+        year = target.year,
+        revision = row.1,
+        restored_from = exchange_id,
+        was_revision = target.revision,
+        "earlier revision restored"
+    );
+
+    Ok(Exchange {
+        id: row.0,
+        revision: row.1,
+        adjusted_from: Some(exchange_id),
+        adjustment_note: Some(note),
+        ..target
+    })
+}
+
 #[cfg(all(test, feature = "server"))]
 mod tests {
     use super::*;

--- a/christmas/src/server/mod.rs
+++ b/christmas/src/server/mod.rs
@@ -7,7 +7,9 @@ mod pools;
 mod relationships;
 mod session;
 
-pub use draw::{apply_swap, exchange_detail, list_exchanges, list_year, preview_swap, record_past_draw, run_draw};
+pub use draw::{
+    apply_swap, exchange_detail, list_exchanges, list_year, preview_swap, record_past_draw, restore_revision, run_draw,
+};
 pub use letters::{list_all_excluded_letters, list_excluded_letters, set_excluded_letters};
 pub use participants::{add_participant, list_participants, remove_participant};
 pub use pools::{add_member, create_pool, delete_pool, list_memberships, list_pools, pool_detail, remove_member};

--- a/christmas/tests/draw_integration.rs
+++ b/christmas/tests/draw_integration.rs
@@ -420,3 +420,77 @@ fn only_the_live_revision_can_be_adjusted() {
             .expect("the live revision adjusts fine");
     });
 }
+
+#[test]
+#[ignore = "needs a database"]
+fn restoring_an_earlier_revision_brings_its_pairings_back() {
+    rt().block_on(async {
+        reset().await;
+        let pool_id = pool_id_for("pets").await;
+
+        let first = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("first draw");
+        let second = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("second draw");
+        assert_eq!(second.revision, 2);
+
+        let restored = server::restore_revision(first.id)
+            .await
+            .expect("restore the first draw");
+
+        assert_eq!(restored.revision, 3, "a restore is recorded, not a rollback");
+        assert_ne!(restored.id, first.id, "both earlier revisions must survive");
+        assert_eq!(restored.pairings, first.pairings);
+        assert_eq!(restored.letter, first.letter);
+        assert_eq!(restored.adjusted_from, Some(first.id));
+        assert_eq!(restored.adjustment_note.as_deref(), Some("Restored revision 1"));
+        // The pairings are the ones this seed produced, so it still replays them.
+        assert_eq!(restored.seed, first.seed);
+
+        // The live draw for the year is now the restored one.
+        let live = server::list_year(2026)
+            .await
+            .expect("year")
+            .into_iter()
+            .find(|e| e.pool_id == pool_id)
+            .expect("a live draw");
+        assert_eq!(live.id, restored.id);
+        assert_eq!(live.pairings, first.pairings);
+
+        // Nothing was deleted on the way.
+        let history = server::list_exchanges(Some(pool_id)).await.expect("history");
+        assert_eq!(history.len(), 3);
+
+        // And the restore is itself undoable.
+        let back = server::restore_revision(second.id).await.expect("restore the second");
+        assert_eq!(back.revision, 4);
+        assert_eq!(back.pairings, second.pairings);
+    });
+}
+
+#[test]
+#[ignore = "needs a database"]
+fn restoring_the_current_revision_is_refused() {
+    rt().block_on(async {
+        reset().await;
+        let pool_id = pool_id_for("pets").await;
+
+        let draw = server::run_draw(pool_id, 2026, config(CycleMode::Grand), true)
+            .await
+            .expect("draw");
+
+        // Nothing to do, and doing it anyway would pad the history with copies.
+        let refused = server::restore_revision(draw.id).await;
+        assert!(refused.is_err(), "the live revision is already current");
+
+        assert!(
+            server::restore_revision(draw.id + 9999).await.is_err(),
+            "an unknown draw is not restorable"
+        );
+
+        let history = server::list_exchanges(Some(pool_id)).await.expect("history");
+        assert_eq!(history.len(), 1, "a refused restore must record nothing");
+    });
+}


### PR DESCRIPTION
Every draw, re-draw and hand adjustment is already kept, so the way back
from a change you regret was on the record — there was just no way to
take it. Manage now lists each year with more than one revision and
restores any of them.

A restore writes the old pairings again as the next revision rather than
deleting or renumbering anything, so "which draw is live" stays the one
question of which revision is highest, the revisions stepped back over
survive, and a restore is itself undone by restoring what it replaced.
It records adjusted_from and a "Restored revision N" note, so the pool
page and the audit trail stay honest about a human having intervened.

The seed comes along, unlike a swap: these really are the pairings that
seed produced, so it still replays them.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>